### PR TITLE
Switch to Explicit cast()

### DIFF
--- a/lib/onesignal.dart
+++ b/lib/onesignal.dart
@@ -160,7 +160,7 @@ class OneSignal {
   /// This method can often take more than five seconds to complete,
   /// so please do NOT block any user-interactive content while
   /// waiting for this request to complete.
-  Future<Map<String, dynamic>> sendTag(dynamic key, dynamic value) async {
+  Future<Map<String, dynamic>> sendTag(String key, dynamic value) async {
     Map<dynamic, dynamic> response = await this.sendTags({ key : value });
     return response.cast<String, dynamic>();
   }
@@ -169,7 +169,7 @@ class OneSignal {
   /// This method can often take more than five seconds to complete,
   /// so please do NOT block any user-interactive content while
   /// waiting for this request to complete.
-  Future<Map<String, dynamic>> sendTags(Map<dynamic, dynamic> tags) async {
+  Future<Map<String, dynamic>> sendTags(Map<String, dynamic> tags) async {
     Map<dynamic, dynamic> response = await _tagsChannel.invokeMethod("OneSignal#sendTags", tags);
     return response.cast<String, dynamic>();
   }
@@ -207,7 +207,7 @@ class OneSignal {
   Future<OSPermissionSubscriptionState> getPermissionSubscriptionState() async {
     var json = await _channel.invokeMethod("OneSignal#getPermissionSubscriptionState");
 
-    return OSPermissionSubscriptionState(json);
+    return OSPermissionSubscriptionState(json.cast<String, dynamic>());
   }
 
   /// Allows you to manually disable or enable push notifications for this user.
@@ -215,17 +215,19 @@ class OneSignal {
   /// permission status. If the user disabled (or never allowed) your application
   /// to send push notifications, calling setSubscription(true) will not change that.
   Future<void> setSubscription(bool enable) async {
-    await _channel.invokeMethod("OneSignal#setSubscription", enable);
+    return await _channel.invokeMethod("OneSignal#setSubscription", enable);
   }
 
   /// Allows you to post a notification to the current user (or a different user 
   /// if you specify their OneSignal user ID).
-  Future<Map<dynamic, dynamic>> postNotificationWithJson(Map<dynamic, dynamic> json) async {
-    return await _channel.invokeMethod("OneSignal#postNotification", json);
+  Future<Map<String, dynamic>> postNotificationWithJson(Map<String, dynamic> json) async {
+    Map<dynamic, dynamic> response = await _channel.invokeMethod("OneSignal#postNotification", json);
+    return response.cast<String, dynamic>();
   }
 
-  Future<Map<dynamic, dynamic>> postNotification(OSCreateNotification notification) async {
-    return await _channel.invokeMethod("OneSignal#postNotification", notification.mapRepresentation());
+  Future<Map<String, dynamic>> postNotification(OSCreateNotification notification) async {
+    Map<dynamic, dynamic> response = await _channel.invokeMethod("OneSignal#postNotification", notification.mapRepresentation());
+    return response.cast<String, dynamic>();
   }
 
   /// Allows you to prompt the user for permission to use location services
@@ -260,15 +262,15 @@ class OneSignal {
   // Private function that gets called by ObjC/Java
   Future<Null> _handleMethod(MethodCall call) async {
     if (call.method == 'OneSignal#handleReceivedNotification' && this._onReceivedNotification != null) {
-      return this._onReceivedNotification(OSNotification(call.arguments as Map<dynamic, dynamic>));
+      return this._onReceivedNotification(OSNotification(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#handleOpenedNotification' && this._onOpenedNotification != null) {
-      return this._onOpenedNotification(OSNotificationOpenedResult(call.arguments as Map<dynamic, dynamic>));
+      return this._onOpenedNotification(OSNotificationOpenedResult(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#subscriptionChanged' && this._onSubscriptionChangedHandler != null) {
-      return this._onSubscriptionChangedHandler(OSSubscriptionStateChanges(call.arguments as Map<dynamic, dynamic>));
+      return this._onSubscriptionChangedHandler(OSSubscriptionStateChanges(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#permissionChanged' && this._onPermissionChangedHandler != null) {
-      return this._onPermissionChangedHandler(OSPermissionStateChanges(call.arguments as Map<dynamic, dynamic>));
+      return this._onPermissionChangedHandler(OSPermissionStateChanges(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#emailSubscriptionChanged' && this._onEmailSubscriptionChangedHandler != null) {
-      return this._onEmailSubscriptionChangedHandler(OSEmailSubscriptionStateChanges(call.arguments as Map<dynamic, dynamic>));
+      return this._onEmailSubscriptionChangedHandler(OSEmailSubscriptionStateChanges(call.arguments.cast<String, dynamic>()));
     }
 
     return null;

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -36,8 +36,8 @@ class OSNotification extends JSONStringRepresentable {
   int androidNotificationId;
 
   //converts JSON map to OSNotification instance
-  OSNotification(Map<dynamic, dynamic> json) {
-    this.payload = OSNotificationPayload(json['payload'] as Map<dynamic, dynamic>);
+  OSNotification(Map<String, dynamic> json) {
+    this.payload = OSNotificationPayload(json['payload'].cast<String, dynamic>());
     this.shown = json['shown'] as bool;
     this.appInFocus = json['appInFocus'] as bool;
     this.silent = json['silent'] as bool;
@@ -121,11 +121,11 @@ class OSNotificationPayload extends JSONStringRepresentable {
 
   /// Any additional custom data you want to send along
   /// with this notification.
-  Map<dynamic, dynamic> additionalData;
+  Map<String, dynamic> additionalData;
 
   /// Any attachments (images, sounds, videos) you want
   /// to display with this notification.
-  Map<dynamic, dynamic> attachments;
+  Map<String, dynamic> attachments;
 
   /// Any buttons you want to add to the notification.
   /// The notificationOpened handler will provide an
@@ -135,7 +135,7 @@ class OSNotificationPayload extends JSONStringRepresentable {
 
   /// A hashmap object representing the raw key/value 
   /// properties of the push notification
-  dynamic rawPayload;
+  Map<String, dynamic> rawPayload;
 
   /// (Android Only)
   /// The filename of the image to use as the small
@@ -211,7 +211,7 @@ class OSNotificationPayload extends JSONStringRepresentable {
   /// notification (if set)
   OSAndroidBackgroundImageLayout backgroundImageLayout;
 
-  OSNotificationPayload(Map<dynamic, dynamic> json) {
+  OSNotificationPayload(Map<String, dynamic> json) {
     this.notificationId = json['notificationId'] as String;
 
     // iOS Specific Parameters
@@ -221,7 +221,7 @@ class OSNotificationPayload extends JSONStringRepresentable {
     if (json.containsKey('badge')) this.badge = json['badge'] as int;
     if (json.containsKey('badgeIncrement')) this.badgeIncrement = json['badgeIncrement'] as int;
     if (json.containsKey('subtitle')) this.subtitle = json['subtitle'] as String;
-    if (json.containsKey('attachments')) this.attachments = json['attachments'] as Map<dynamic, dynamic>;
+    if (json.containsKey('attachments')) this.attachments = json['attachments'].cast<String, dynamic>();
 
     // Android Specific Parameters
     if (json.containsKey("smallIcon")) this.smallIcon = json['smallIcon'] as String;
@@ -242,10 +242,10 @@ class OSNotificationPayload extends JSONStringRepresentable {
     if (json.containsKey('title')) this.title = json['title'] as String;
     if (json.containsKey('body')) this.body = json['body'] as String;
     if (json.containsKey('launchUrl')) this.launchUrl = json['launchUrl'] as String;
-    if (json.containsKey('additionalData')) this.additionalData = json['additionalData'] as Map<dynamic, dynamic>;
+    if (json.containsKey('additionalData')) this.additionalData = json['additionalData'].cast<String, dynamic>();
     
     if (json.containsKey('backgroundImageLayout')) {
-      this.backgroundImageLayout = OSAndroidBackgroundImageLayout(json['backgroundImageLayout'] as Map<dynamic, dynamic>);
+      this.backgroundImageLayout = OSAndroidBackgroundImageLayout(json['backgroundImageLayout'].cast<String, dynamic>());
     }
 
     // raw payload comes as a JSON string
@@ -259,7 +259,7 @@ class OSNotificationPayload extends JSONStringRepresentable {
       this.buttons = List<OSActionButton>();
       var btns = json['buttons'] as List<dynamic>;
       for (var btn in btns) {
-        var serialized = btn as Map<dynamic, dynamic>;
+        var serialized = btn.cast<String, dynamic>();
         this.buttons.add(OSActionButton.fromJson(serialized));
       }
     }
@@ -279,11 +279,11 @@ class OSNotificationOpenedResult {
   OSNotificationAction action;
 
   //constructor
-  OSNotificationOpenedResult(Map<dynamic, dynamic> json) {
-    this.notification = OSNotification(json['notification'] as Map<dynamic, dynamic>);
+  OSNotificationOpenedResult(Map<String, dynamic> json) {
+    this.notification = OSNotification(json['notification'].cast<String, dynamic>());
 
     if (json.containsKey('action')) { 
-      this.action = OSNotificationAction(json['action'] as Map<dynamic, dynamic>); 
+      this.action = OSNotificationAction(json['action'].cast<String, dynamic>()); 
     }
   }
 }
@@ -305,7 +305,7 @@ class OSNotificationAction {
   /// that the user tapped
   String actionId;
 
-  OSNotificationAction(Map<dynamic, dynamic> json) {
+  OSNotificationAction(Map<String, dynamic> json) {
     this.type = OSNotificationActionType.opened;
     this.actionId = json['id'] as String;
 
@@ -330,7 +330,7 @@ class OSActionButton extends JSONStringRepresentable {
 
   OSActionButton({@required this.id, @required this.text, this.icon});
 
-  OSActionButton.fromJson(Map<dynamic, dynamic> json) {
+  OSActionButton.fromJson(Map<String, dynamic> json) {
     this.id = json['id'] as String;
     this.text = json['text'] as String;
 
@@ -366,7 +366,7 @@ class OSAndroidBackgroundImageLayout extends JSONStringRepresentable {
   /// The color of the body text
   String bodyTextColor;
 
-  OSAndroidBackgroundImageLayout(Map<dynamic, dynamic> json) {
+  OSAndroidBackgroundImageLayout(Map<String, dynamic> json) {
     if (json.containsKey('image')) this.image = json['image'] as String;
     if (json.containsKey('titleTextColor')) this.titleTextColor = json['titleTextColor'] as String;
     if (json.containsKey('bodyTextColor')) this.bodyTextColor = json['bodyTextColor'] as String;

--- a/lib/src/permission.dart
+++ b/lib/src/permission.dart
@@ -7,7 +7,7 @@ class OSPermissionState extends JSONStringRepresentable {
   bool provisional; //iOS only
   OSNotificationPermission status;
   
-  OSPermissionState(Map<dynamic, dynamic> json) {
+  OSPermissionState(Map<String, dynamic> json) {
     
     if (json.containsKey('status')) {
       //ios
@@ -44,10 +44,10 @@ class OSPermissionSubscriptionState extends JSONStringRepresentable {
   OSSubscriptionState subscriptionStatus;
   OSEmailSubscriptionState emailSubscriptionStatus;
 
-  OSPermissionSubscriptionState(Map<dynamic, dynamic> json) {
-    this.permissionStatus = OSPermissionState(json['permissionStatus']);
-    this.subscriptionStatus = OSSubscriptionState(json['subscriptionStatus']);
-    this.emailSubscriptionStatus = OSEmailSubscriptionState(json['emailSubscriptionStatus']);
+  OSPermissionSubscriptionState(Map<String, dynamic> json) {
+    this.permissionStatus = OSPermissionState(json['permissionStatus'].cast<String, dynamic>());
+    this.subscriptionStatus = OSSubscriptionState(json['subscriptionStatus'].cast<String, dynamic>());
+    this.emailSubscriptionStatus = OSEmailSubscriptionState(json['emailSubscriptionStatus'].cast<String, dynamic>());
   }
 
   String jsonRepresentation() {
@@ -63,7 +63,7 @@ class OSPermissionStateChanges extends JSONStringRepresentable {
   OSPermissionState from;
   OSPermissionState to;
 
-  OSPermissionStateChanges(Map<dynamic, dynamic> json) {
+  OSPermissionStateChanges(Map<String, dynamic> json) {
     this.from = OSPermissionState(json['from']);
     this.to = OSPermissionState(json['to']);
   }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -19,7 +19,7 @@ class OSSubscriptionState extends JSONStringRepresentable {
   /// The APNS (iOS), GCM/FCM (Android) push token
   String pushToken;
   
-  OSSubscriptionState(Map<dynamic, dynamic> json) {
+  OSSubscriptionState(Map<String, dynamic> json) {
     this.subscribed = json['subscribed'] as bool;
     this.userSubscriptionSetting = json['userSubscriptionSetting'] as bool;
 
@@ -44,9 +44,9 @@ class OSSubscriptionStateChanges extends JSONStringRepresentable {
   OSSubscriptionState from;
   OSSubscriptionState to;
 
-  OSSubscriptionStateChanges(Map<dynamic, dynamic> json) {
-    if (json.containsKey('from')) this.from = OSSubscriptionState(json['from'] as Map<dynamic, dynamic>);
-    if (json.containsKey('to')) this.to = OSSubscriptionState(json['to'] as Map<dynamic, dynamic>);
+  OSSubscriptionStateChanges(Map<String, dynamic> json) {
+    if (json.containsKey('from')) this.from = OSSubscriptionState(json['from'].cast<String, dynamic>());
+    if (json.containsKey('to')) this.to = OSSubscriptionState(json['to'].cast<String, dynamic>());
   }
 
   String jsonRepresentation() {
@@ -63,7 +63,7 @@ class OSEmailSubscriptionState extends JSONStringRepresentable {
   String emailUserId;
   String emailAddress;
 
-  OSEmailSubscriptionState(Map<dynamic, dynamic> json) {
+  OSEmailSubscriptionState(Map<String, dynamic> json) {
     this.subscribed = false;
 
     if (json.containsKey('emailAddress') && json['emailAddress'] != null) 
@@ -90,7 +90,7 @@ class OSEmailSubscriptionStateChanges extends JSONStringRepresentable {
   OSEmailSubscriptionState from;
   OSEmailSubscriptionState to;
 
-  OSEmailSubscriptionStateChanges(Map<dynamic, dynamic> json) {
+  OSEmailSubscriptionStateChanges(Map<String, dynamic> json) {
     if (json.containsKey('from')) this.from = OSEmailSubscriptionState(json['from']);
     if (json.containsKey('to')) this.to = OSEmailSubscriptionState(json['to']);
   }

--- a/test/mock_channel.dart
+++ b/test/mock_channel.dart
@@ -50,7 +50,7 @@ class OneSignalMockChannelController {
         break;
       case "OneSignal#postNotification":
         this.state.postNotificationJson = call.arguments as Map<dynamic, dynamic>;
-        break;
+        return {"success" : true};
       case "OneSignal#setLocationShared":
         this.state.locationShared = call.arguments as bool;
         break;

--- a/test/permission_test.dart
+++ b/test/permission_test.dart
@@ -6,7 +6,7 @@ import 'test_data.dart';
 
 void main() {
   // Permission State tests
-  final permissionStateChangesJson = TestData.jsonForTest("permission_parsing_test") as Map<dynamic, dynamic>;
+  final permissionStateChangesJson = TestData.jsonForTest("permission_parsing_test") as Map<String, dynamic>;
   final permissionStateChanges = OSPermissionStateChanges(permissionStateChangesJson);
 
   test('expect permission to parse hasPrompted correctly', () {

--- a/test/subscription_test.dart
+++ b/test/subscription_test.dart
@@ -5,7 +5,7 @@ import 'test_data.dart';
 void main() {
   // Subscription State Tests
   // Tests both OSSubscriptionStateChanges and OSSubscriptionState model parsing
-  final subscriptionStateChanges = TestData.jsonForTest('subscription_changed_test') as Map<dynamic, dynamic>;
+  final subscriptionStateChanges = TestData.jsonForTest('subscription_changed_test') as Map<String, dynamic>;
   final subscriptionChanges = OSSubscriptionStateChanges(subscriptionStateChanges);
 
   test('expect subscription correctly parses user ID', () {
@@ -28,7 +28,7 @@ void main() {
 
   // Email Subscription State Tests
   // Tests both OSEmailSubscriptionStateChanges and OSEmailSubscriptionState model parsing
-  final emailStateChanges = TestData.jsonForTest('email_changed_test') as Map<dynamic, dynamic>;
+  final emailStateChanges = TestData.jsonForTest('email_changed_test') as Map<String, dynamic>;
   final emailChanges = OSEmailSubscriptionStateChanges(emailStateChanges);
 
   test ('expect subscription correctly parses email address', () {


### PR DESCRIPTION
• Discovered that non-string values are not allowed to exist in notifications/tags/etc, so I have changed the SDK to use Map<String, dynamic> instead of allowing dynamic keys.
• Because of how Dart's cast system works, this requires us to explicitly use cast<String, dynamic>()