### PR TITLE
Fix Incorrect Context

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -98,7 +98,7 @@ public class OneSignalPlugin implements MethodCallHandler, NotificationReceivedH
 
   private void initOneSignal(MethodCall call, Result result) {
     String appId = call.argument("appId");
-    Context context = flutterRegistrar.context();
+    Context context = flutterRegistrar.activeContext();
 
     OneSignal.Builder builder = OneSignal.getCurrentOrNewInitBuilder();
     builder.unsubscribeWhenNotificationsAreDisabled(true);
@@ -164,8 +164,8 @@ public class OneSignalPlugin implements MethodCallHandler, NotificationReceivedH
   }
 
   private void setInFocusDisplayType(MethodCall call, Result result) {
-    int deplayType = call.argument("displayType");
-    OneSignal.setInFocusDisplaying(deplayType);
+    int displayType = call.argument("displayType");
+    OneSignal.setInFocusDisplaying(displayType);
     result.success(null);
   }
 


### PR DESCRIPTION
• The OneSignalPlugin was initializing the native OneSignal SDK with an incorrect context. Switched to using the flutter registrar's activeContext instead.
• This would have caused the SDK to always believe that the app was not currently in focus, meaning the SDK would ignore the current inFocusDisplayType option and always show notifications as normal Android notifications
• Fixes issue #7 