### PR TITLE
Fix type issue

### DIFF
--- a/lib/onesignal.dart
+++ b/lib/onesignal.dart
@@ -263,7 +263,7 @@ class OneSignal {
   }
 
   // Private function that gets called by ObjC/Java
-  Future<Null> _handleMethod(MethodCall call) async {
+  Future<void> _handleMethod(MethodCall call) async {
     if (call.method == 'OneSignal#handleReceivedNotification' &&
         this._onReceivedNotification != null) {
       return this._onReceivedNotification(


### PR DESCRIPTION
To get rid of these compiler messages:

```
compiler message: file:///Users/figengungor/Documents/development/OneSignal-Flutter-SDK/lib/onesignal.dart:269:19: Warning: This expression has type 'void' and can't be used.
compiler message:       return this._onReceivedNotification(
compiler message:                   ^
compiler message: file:///Users/figengungor/Documents/development/OneSignal-Flutter-SDK/lib/onesignal.dart:273:19: Warning: This expression has type 'void' and can't be used.
compiler message:       return this._onOpenedNotification(
compiler message:                   ^
compiler message: file:///Users/figengungor/Documents/development/OneSignal-Flutter-SDK/lib/onesignal.dart:277:19: Warning: This expression has type 'void' and can't be used.
compiler message:       return this._onSubscriptionChangedHandler(
compiler message:                   ^
compiler message: file:///Users/figengungor/Documents/development/OneSignal-Flutter-SDK/lib/onesignal.dart:281:19: Warning: This expression has type 'void' and can't be used.
compiler message:       return this._onPermissionChangedHandler(
compiler message:                   ^
compiler message: file:///Users/figengungor/Documents/development/OneSignal-Flutter-SDK/lib/onesignal.dart:285:19: Warning: This expression has type 'void' and can't be used.
compiler message:       return this._onEmailSubscriptionChangedHandler(
compiler message:                   ^
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```