### PR TITLE
Fix null optional parameter bug

### DIFF
--- a/lib/onesignal.dart
+++ b/lib/onesignal.dart
@@ -298,18 +298,19 @@ class OneSignal {
 
   Map<String, dynamic> _processSettings(Map<OSiOSSettings, dynamic> settings) {
     var finalSettings = Map<String, dynamic>();
+    if (settings != null) {
+      for (OSiOSSettings key in settings.keys) {
+        var settingsKey = convertEnumCaseToValue(key);
+        var settingsValue = convertEnumCaseToValue(settings[key]);
 
-    for (OSiOSSettings key in settings.keys) {
-      var settingsKey = convertEnumCaseToValue(key);
-      var settingsValue = convertEnumCaseToValue(settings[key]);
+        if (settingsKey == null) continue;
 
-      if (settingsKey == null) continue;
-
-      //we check if the value is also an enum case
-      //ie. if they pass OSNotificationDisplayType,
-      //we want to convert it to an integer before
-      //passing the parameter to the ObjC bridge.
-      finalSettings[settingsKey] = settingsValue ?? settings[key];
+        //we check if the value is also an enum case
+        //ie. if they pass OSNotificationDisplayType,
+        //we want to convert it to an integer before
+        //passing the parameter to the ObjC bridge.
+        finalSettings[settingsKey] = settingsValue ?? settings[key];
+      }
     }
 
     return finalSettings;


### PR DESCRIPTION
Add null check for `settings` inside `_processSettings` method.

```
  /// The initializer for OneSignal. Note that this initializer
  /// accepts an iOSSettings object, in Android you can pass null.
  Future<void> init(String appId,
      {Map<OSiOSSettings, dynamic> iOSSettings}) async {
    _onesignalLog(OSLogLevel.verbose,
        "Initializing the OneSignal Flutter SDK ($sdkVersion)");

    var finalSettings = _processSettings(iOSSettings);

    await _channel.invokeMethod(
        'OneSignal#init', {'appId': appId, 'settings': finalSettings});
  }
```

When iOSSettings optional parameter is not provided, the _processSettings fails because trying to reach a property of this null parameter 

```
Map<String, dynamic> _processSettings(Map<OSiOSSettings, dynamic> settings) {
    var finalSettings = Map<String, dynamic>();
      for (OSiOSSettings key in settings.keys) {
        var settingsKey = convertEnumCaseToValue(key);
        var settingsValue = convertEnumCaseToValue(settings[key]);

        if (settingsKey == null) continue;

        //we check if the value is also an enum case
        //ie. if they pass OSNotificationDisplayType,
        //we want to convert it to an integer before
        //passing the parameter to the ObjC bridge.
        finalSettings[settingsKey] = settingsValue ?? settings[key];
      }
```