### PR TITLE
Fix Android No Tags Null Pointer Exception

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -199,6 +199,9 @@ public class OneSignalSerializer {
     static public HashMap<String, Object> convertJSONObjectToHashMap(JSONObject object) throws JSONException {
         HashMap<String, Object> hash = new HashMap<>();
 
+        if (object == null)
+           return hash;
+
         Iterator<String> keys = object.keys();
 
         while (keys.hasNext()) {


### PR DESCRIPTION
• In cases where a user had no tags and the app called getTags(), the serializer wrapper would attempt to iterate through keys on a null object causing a null pointer exception
• Fixed issue by adding an early return in the serializer
• Fixes #15 

**NOTE** The typical reviewer for these PR's (@jkasten2) is out on vacation for the next week, so to avoid delaying builds, we will merge and release without review. 