### PR TITLE
Fix Type Conversion Warning

### DIFF
--- a/lib/onesignal.dart
+++ b/lib/onesignal.dart
@@ -266,23 +266,23 @@ class OneSignal {
   Future<Null> _handleMethod(MethodCall call) async {
     if (call.method == 'OneSignal#handleReceivedNotification' &&
         this._onReceivedNotification != null) {
-      return this._onReceivedNotification(
+      this._onReceivedNotification(
           OSNotification(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#handleOpenedNotification' &&
         this._onOpenedNotification != null) {
-      return this._onOpenedNotification(
+      this._onOpenedNotification(
           OSNotificationOpenedResult(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#subscriptionChanged' &&
         this._onSubscriptionChangedHandler != null) {
-      return this._onSubscriptionChangedHandler(
+      this._onSubscriptionChangedHandler(
           OSSubscriptionStateChanges(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#permissionChanged' &&
         this._onPermissionChangedHandler != null) {
-      return this._onPermissionChangedHandler(
+      this._onPermissionChangedHandler(
           OSPermissionStateChanges(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#emailSubscriptionChanged' &&
         this._onEmailSubscriptionChangedHandler != null) {
-      return this._onEmailSubscriptionChangedHandler(
+      this._onEmailSubscriptionChangedHandler(
           OSEmailSubscriptionStateChanges(
               call.arguments.cast<String, dynamic>()));
     }


### PR DESCRIPTION
• Fixes an issue with the SDK that would print a warning for the private _handleMethod() method.
• It was returning the results of calling private handler references, which themselves returned void. However the function is defined to return Future<Null> not void, so a warning was printed.
• Fixed by returning null at the end. The result of this function is not used and the SDK does not need to wait asynchronously for the handlers to finish executing.
• Fixes #14 

**NOTE** The typical reviewer for these PR's (@jkasten2) is out on vacation for the next week, so to avoid delaying builds, we will merge and release without review. 