### PR TITLE
Fix Initialization Exception

### DIFF
--- a/lib/onesignal.dart
+++ b/lib/onesignal.dart
@@ -299,6 +299,8 @@ class OneSignal {
   Map<String, dynamic> _processSettings(Map<OSiOSSettings, dynamic> settings) {
     var finalSettings = Map<String, dynamic>();
 
+    if (settings == null) return finalSettings;
+
     for (OSiOSSettings key in settings.keys) {
       var settingsKey = convertEnumCaseToValue(key);
       var settingsValue = convertEnumCaseToValue(settings[key]);

--- a/test/onesignal_test.dart
+++ b/test/onesignal_test.dart
@@ -21,6 +21,11 @@ void main() {
     }));
   });
 
+  test('verify initialization without iOS Settings', () {
+    onesignal.init(testAppId);
+    expect(channelController.state.appId, testAppId);
+  });
+
   test('set set log level', () {
     onesignal
         .setLogLevel(OSLogLevel.info, OSLogLevel.warn)


### PR DESCRIPTION
• The init() method is intended to accept iOS Settings as an optional parameter
• However it appears that it would cause an exception if settings were not provided.
• Added regression test case to ensure init() works without iOS Settings
• Fixes #11 

**NOTE** The typical reviewer for these PR's (@jkasten2) is out on vacation for the next week, so to avoid delaying builds, we will merge and release without review. 