### PR TITLE
Fix JSON Null Pointer Exception

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -199,14 +199,19 @@ public class OneSignalSerializer {
     static public HashMap<String, Object> convertJSONObjectToHashMap(JSONObject object) throws JSONException {
         HashMap<String, Object> hash = new HashMap<>();
 
-        if (object == null)
+        if (object == null || object == JSONObject.NULL)
            return hash;
 
         Iterator<String> keys = object.keys();
 
         while (keys.hasNext()) {
             String key = keys.next();
+
+            if (object.isNull(key))
+                continue;
+
             Object val = object.get(key);
+
             if (val instanceof JSONArray) {
                 val = convertJSONArrayToList((JSONArray)val);
             } else if (val instanceof JSONObject) {


### PR DESCRIPTION
• Fixes a null pointer exception in our JSONObject -> Hash Map helper conversion function
• It turns out that if there is a null value in a JSON object, using an equality check against null (obj == null) will return false
• This is because in Android's JSONObject implementation, null values are actually pointers to JSONObject.NULL and an equality check against Java's null will return false
• Fixed by checking for this case and will skip adding null values to hashmaps (which would throw an exception in Flutter's Java wrapper)