### PR TITLE
Removed Android Support use in wrapper code

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/FlutterRegistrarResponder.java
+++ b/android/src/main/java/com/onesignal/flutter/FlutterRegistrarResponder.java
@@ -1,7 +1,6 @@
 package com.onesignal.flutter;
 
 import android.app.Activity;
-import android.support.annotation.NonNull;
 
 import java.util.HashMap;
 
@@ -54,11 +53,11 @@ abstract class FlutterRegistrarResponder {
       });
    }
 
-   protected void runOnMainThread(@NonNull final Runnable runnable) {
+   protected void runOnMainThread(final Runnable runnable) {
       ((Activity)flutterRegistrar.activeContext()).runOnUiThread(runnable);
    }
 
-   protected void invokeMethodOnUiThread(@NonNull final String methodName, @NonNull final HashMap map) {
+   protected void invokeMethodOnUiThread(final String methodName, final HashMap map) {
       final MethodChannel channel = this.channel;
       runOnMainThread(new Runnable() {
          @Override

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -1,7 +1,6 @@
 package com.onesignal.flutter;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 
 import com.onesignal.OSEmailSubscriptionObserver;
 import com.onesignal.OSEmailSubscriptionStateChanges;
@@ -66,7 +65,7 @@ public class OneSignalPlugin
   }
 
   @Override
-  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
+  public void onMethodCall(MethodCall call, Result result) {
     if (call.method.contentEquals("OneSignal#init"))
       initOneSignal(call, result);
     else if (call.method.contentEquals("OneSignal#setLogLevel"))

--- a/android/src/main/java/com/onesignal/flutter/OneSignalTagsController.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalTagsController.java
@@ -1,7 +1,5 @@
 package com.onesignal.flutter;
 
-import android.support.annotation.NonNull;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -31,7 +29,7 @@ class OSFlutterChangeTagsHandler extends FlutterRegistrarResponder implements Ch
     // the tags callbacks can in some instances be called more than once
     // ie. cached vs. server response.
     // this property guarantees the callback will never be called more than once.
-    @NonNull private AtomicBoolean replySubmitted = new AtomicBoolean(false);
+    private AtomicBoolean replySubmitted = new AtomicBoolean(false);
 
     OSFlutterChangeTagsHandler(PluginRegistry.Registrar flutterRegistrar, MethodChannel channel, Result res) {
         this.flutterRegistrar = flutterRegistrar;
@@ -84,7 +82,7 @@ public class OneSignalTagsController implements MethodCallHandler {
     }
 
     @Override
-    public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
+    public void onMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#getTags"))
             OneSignal.getTags(new OSFlutterChangeTagsHandler(registrar, channel, result));
         else if (call.method.contentEquals("OneSignal#sendTags"))


### PR DESCRIPTION
* Removed use of android.support.annotations which was included for @NonNull
* This was done instead of switches these .java source files to AndroidX as the main native OneSignal SDK hasn't switch over yet.
   - Also having a mixture would add more confusion and would require Jetifier to always be enabled