### PR TITLE
Removed presentApplicationSettings in favor of fallbackToSettings

### DIFF
--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -146,11 +146,6 @@ class OneSignal {
     return result as bool;
   }
 
-  /// in iOS, takes the user to the iOS Settings page for this app.
-  Future<void> presentApplicationSettings() async {
-    await _channel.invokeMethod("OneSignal#presentSettings");
-  }
-
   /// The current setting that controls how notifications are displayed.
   Future<OSNotificationDisplayType> inFocusDisplayType() async {
     int type = await _channel.invokeMethod("OneSignal#inFocusDisplayType");


### PR DESCRIPTION
This function didn't do anything and was throwing an error when used. `fallbackToSettings` should be used instead when prompting

Fixes #129 