### PR TITLE
Fixed setEmail without emailAuthHash for Android

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -264,9 +264,6 @@ public class OneSignalPlugin
     String email = call.argument("email");
     String emailAuthHashToken = call.argument("emailAuthHashToken");
 
-    if (email == null || emailAuthHashToken == null)
-      return;
-
     OneSignal.setEmail(email, emailAuthHashToken, new EmailUpdateHandler() {
       @Override
       public void onSuccess() {


### PR DESCRIPTION
* setEmail did not work on Android without emailAuthHash
   - Nor did it resolve its Future.
* Removed null checking for both email and emailAuthHash as the native Android setEmail already handles this.
* Fixes #214