### PR TITLE
fix(delayed_option): allow to schedule notifications

### DIFF
--- a/lib/src/create_notification.dart
+++ b/lib/src/create_notification.dart
@@ -168,7 +168,7 @@ class OSCreateNotification extends JSONStringRepresentable {
     if (this.iosBadgeType != null)
       json['ios_badgeType'] = convertEnumCaseToValue(this.iosBadgeType);
     if (this.delayedOption != null)
-      json['delay_option'] = convertEnumCaseToValue(this.delayedOption);
+      json['delayed_option'] = convertEnumCaseToValue(this.delayedOption);
 
     // adds buttons
     if (this.buttons != null) {

--- a/test/create_notification_test.dart
+++ b/test/create_notification_test.dart
@@ -86,7 +86,7 @@ void main() {
   });
 
   test('expect delayed option to be parsed correctly', () {
-    expect(notificationJson['delay_option'], 'last_active');
+    expect(notificationJson['delayed_option'], 'last_active');
   });
 
   test('expect delivery time of day to be parsed correctly', () {


### PR DESCRIPTION
This change fixes the `delayed_option` property which was uncorrectly specified and it is currently breaking the option to schedule notifications from the client.

fix #267