### PR TITLE
feat(ttl): support ttl in OSCreateNotification

### DIFF
--- a/lib/src/create_notification.dart
+++ b/lib/src/create_notification.dart
@@ -83,6 +83,10 @@ class OSCreateNotification extends JSONStringRepresentable {
   /// Allows you to send a notification at a specific date
   DateTime sendAfter;
 
+  /// Time to Live. The default time is 259,200 seconds (3 days) but can be any value from 0 to 2,419,200 seconds.
+  /// The notification will expire if the device remains offline for these number of seconds.
+  int ttl;
+
   /// You can use several options to send notifications at specific times
   /// ie. you can send notifications to different user's at the same time
   /// in each timezone with the 'timezone' delayedOption
@@ -92,38 +96,41 @@ class OSCreateNotification extends JSONStringRepresentable {
   /// each user should receive the notification, ie. "9:00 AM"
   String deliveryTimeOfDay;
 
-  OSCreateNotification(
-      {@required this.playerIds,
-      @required this.content,
-      this.languageCode,
-      this.heading,
-      this.subtitle,
-      this.contentAvailable,
-      this.mutableContent,
-      this.additionalData,
-      this.url,
-      this.iosAttachments,
-      this.bigPicture,
-      this.buttons,
-      this.iosCategory,
-      this.iosSound,
-      this.androidSound,
-      this.androidSmallIcon,
-      this.androidLargeIcon,
-      this.androidChannelId,
-      this.iosBadgeCount,
-      this.iosBadgeType,
-      this.collapseId,
-      this.sendAfter,
-      this.delayedOption,
-      this.deliveryTimeOfDay});
+  OSCreateNotification({
+    @required this.playerIds,
+    @required this.content,
+    this.languageCode,
+    this.heading,
+    this.subtitle,
+    this.contentAvailable,
+    this.mutableContent,
+    this.additionalData,
+    this.url,
+    this.iosAttachments,
+    this.bigPicture,
+    this.buttons,
+    this.iosCategory,
+    this.iosSound,
+    this.androidSound,
+    this.androidSmallIcon,
+    this.androidLargeIcon,
+    this.androidChannelId,
+    this.iosBadgeCount,
+    this.iosBadgeType,
+    this.collapseId,
+    this.sendAfter,
+    this.ttl,
+    this.delayedOption,
+    this.deliveryTimeOfDay,
+  });
 
-  OSCreateNotification.silentNotification(
-      {@required this.playerIds,
-      this.additionalData,
-      this.sendAfter,
-      this.delayedOption,
-      this.deliveryTimeOfDay}) {
+  OSCreateNotification.silentNotification({
+    @required this.playerIds,
+    this.additionalData,
+    this.sendAfter,
+    this.delayedOption,
+    this.deliveryTimeOfDay,
+  }) {
     this.contentAvailable = true;
   }
 
@@ -161,6 +168,7 @@ class OSCreateNotification extends JSONStringRepresentable {
     if (this.collapseId != null) json['collapse_id'] = this.collapseId;
     if (this.deliveryTimeOfDay != null)
       json['delivery_time_of_day'] = this.deliveryTimeOfDay;
+    if (this.ttl != null) json['ttl'] = this.ttl;
 
     // adds optional parameters that require transformations
     if (this.sendAfter != null)

--- a/test/create_notification_test.dart
+++ b/test/create_notification_test.dart
@@ -93,6 +93,10 @@ void main() {
     expect(notificationJson['delivery_time_of_day'], '9:00 AM');
   });
 
+  test('expect ttl to be parsed correctly', () {
+    expect(notificationJson['ttl'], 259200);
+  });
+
   test('expect buttons to be parsed correctly', () {
     var buttonsJson = notificationJson['buttons'] as List<Map<String, dynamic>>;
     expect(buttonsJson.first['id'], 'test_id');

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -48,6 +48,7 @@ final notificationJson = OSCreateNotification(
         iosBadgeType: OSCreateNotificationBadgeType.increase,
         iosBadgeCount: 2,
         collapseId: 'test_collapse_id',
+        ttl: 259200,
         sendAfter: DateTime.fromMillisecondsSinceEpoch(1532464704571,
             isUtc: true), //corresponds to 2018-07-24T20:38:24.571Z UTC00:00:00
         delayedOption: OSCreateNotificationDelayOption.lastActive,


### PR DESCRIPTION
This change adds the capability to pass the ttl parameter to the `postNotification` method. I guess we can always use the `postNotificationWithJson` but I think this is cleaner.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/269)
<!-- Reviewable:end -->

