### PR TITLE
Migrate pluginClass to new format

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,11 @@ homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 flutter:
   plugin:
     androidPackage: com.onesignal.flutter
-    pluginClass: OneSignalPlugin
+    platforms:
+      android:
+        pluginClass: OneSignalPlugin
+      ios:
+        pluginClass: OneSignalPlugin
 
 dependencies:
   flutter:


### PR DESCRIPTION
* pluginClass is deprecated, it can only be defined under platforms

When trying to upload new Flutter version following error was shown:

Package validation found the following error:


* In pubspec.yaml the flutter.plugin.{androidPackage,iosPrefix,pluginClass} keys are deprecated. Instead use the flutter.plugin.platforms key introduced in Flutter 1.10.0

  See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin

