### PR TITLE
Update flutter min version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.10.0 <2.0.0"


### PR DESCRIPTION
## Scope
Update minimum flutter version to 1.10.0, this version is required to user platform pluginClass. Last pluginClass format was deprecated as pointed out under https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/342

Checking flutter release notes seems to be safe to increase the min flutter SDK version since there are a lot of changes in past releases, we will need to update later on and since there is no more support to old versions, we should keep following https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin instructions
https://flutter.dev/docs/development/tools/sdk/release-notes

Flutter error change
https://github.com/dart-lang/pub/pull/2502/files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/343)
<!-- Reviewable:end -->
