### PR TITLE
Add missing method support

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -93,6 +93,8 @@ public class OneSignalPlugin
       this.setRequiresUserPrivacyConsent(call, result);
     else if (call.method.contentEquals("OneSignal#consentGranted"))
       this.consentGranted(call, result);
+    else if (call.method.contentEquals("OneSignal#userProvidedPrivacyConsent"))
+      this.userProvidedPrivacyConsent(call, result);
     else if (call.method.contentEquals("OneSignal#promptPermission"))
       this.promptPermission(call, result);
     else if (call.method.contentEquals("OneSignal#getDeviceState"))
@@ -190,6 +192,12 @@ public class OneSignalPlugin
     }
 
     replySuccess(reply, null);
+  }
+
+  private void userProvidedPrivacyConsent(MethodCall call, Result reply) {
+    boolean result = OneSignal.userProvidedPrivacyConsent();
+
+    replySuccess(reply, result);
   }
 
   private void promptPermission(MethodCall call, Result result) {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -125,6 +125,8 @@ public class OneSignalPlugin
       this.completeNotification(call, result);
     else if (call.method.contentEquals("OneSignal#clearOneSignalNotifications"))
       this.clearOneSignalNotifications(call, result);
+    else if (call.method.contentEquals("OneSignal#removeNotification"))
+      this.removeNotification(call, result);
     else
       replyNotImplemented(result);
   }
@@ -354,6 +356,13 @@ public class OneSignalPlugin
 
   private void clearOneSignalNotifications(MethodCall call, final Result reply) {
     OneSignal.clearOneSignalNotifications();
+
+    replySuccess(reply, null);
+  }
+
+  private void removeNotification(MethodCall call, final Result reply) {
+    int notificationId = call.argument("notificationId");
+    OneSignal.removeNotification(notificationId);
 
     replySuccess(reply, null);
   }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -123,6 +123,8 @@ public class OneSignalPlugin
       this.initNotificationWillShowInForegroundHandlerParams();
     else if (call.method.contentEquals("OneSignal#completeNotification"))
       this.completeNotification(call, result);
+    else if (call.method.contentEquals("OneSignal#clearOneSignalNotifications"))
+      this.clearOneSignalNotifications(call, result);
     else
       replyNotImplemented(result);
   }
@@ -348,6 +350,12 @@ public class OneSignalPlugin
 
   private void initNotificationWillShowInForegroundHandlerParams() {
     this.hasSetNotificationWillShowInForegroundHandler = true;
+  }
+
+  private void clearOneSignalNotifications(MethodCall call, final Result reply) {
+    OneSignal.clearOneSignalNotifications();
+
+    replySuccess(reply, null);
   }
 
   private void completeNotification(MethodCall call, final Result reply) {

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -248,6 +248,12 @@ class OneSignal {
     return await _channel.invokeMethod("OneSignal#clearOneSignalNotifications");
   }
 
+  /// Allows you to manually cancel a single OneSignal notification based on its Android notification integer ID
+  void removeNotification(int notificationId) {
+    _channel.invokeMethod("OneSignal#removeNotification",
+        {'notificationId': notificationId});
+  }
+
   /// Allows you to prompt the user for permission to use location services
   Future<void> promptLocationPermission() async {
     return await _channel.invokeMethod("OneSignal#promptLocation");

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -136,6 +136,14 @@ class OneSignal {
         .invokeMethod("OneSignal#consentGranted", {'granted': granted});
   }
 
+  /// A boolean value indicating if the user provided privacy consent
+  Future<bool> userProvidedPrivacyConsent() async {
+    var val =
+        await _channel.invokeMethod("OneSignal#userProvidedPrivacyConsent");
+
+    return val as bool;
+  }
+
   /// A boolean value indicating if the OneSignal SDK is waiting for the
   /// user's consent before it can initialize (if you set the app to
   /// require the user's consent)

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -243,6 +243,11 @@ class OneSignal {
     return response.cast<String, dynamic>();
   }
 
+  /// Allows you to manually remove all OneSignal notifications from the Notification Shade
+  Future<void> clearOneSignalNotifications() async {
+    return await _channel.invokeMethod("OneSignal#clearOneSignalNotifications");
+  }
+
   /// Allows you to prompt the user for permission to use location services
   Future<void> promptLocationPermission() async {
     return await _channel.invokeMethod("OneSignal#promptLocation");


### PR DESCRIPTION
- Add Android method userProvidedPrivacyConsent support
- Add Android clearOneSignalNotifications method support
- Add Android removeNotification method support

We should add all this method under OneSignal.m iOS public native SDK so we can support them on Flutter and React Native

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/347)
<!-- Reviewable:end -->

