### PR TITLE
Fix FCM compatibility and Android package definition

### DIFF
--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignal', '2.16.2'
+  s.dependency 'OneSignal',  '2.16.3'
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 end

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignal',  '2.16.3'
+  s.dependency 'OneSignal', '2.16.3'
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,9 +6,9 @@ homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 flutter:
   plugin:
-    androidPackage: com.onesignal.flutter
     platforms:
       android:
+        package: com.onesignal.flutter
         pluginClass: OneSignalPlugin
       ios:
         pluginClass: OneSignalPlugin


### PR DESCRIPTION
* Updated to use the latest 2.16.3 version of OneSignal swift api
* Updated the Android package definition to use the correct syntax for package name declaration (was causing a compile error/warning due to using an outdated def)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/349)
<!-- Reviewable:end -->

