### PR TITLE
Fix handlers

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -43,9 +43,7 @@ public class OneSignalPlugin
         OneSignal.OSNotificationWillShowInForegroundHandler {
 
   /** Plugin registration. */
-  private OSNotificationOpenedResult coldStartNotificationResult;
   private OSInAppMessageAction inAppMessageClickedResult;
-  private boolean hasSetNotificationOpenedHandler = false;
   private boolean hasSetInAppMessageClickedHandler = false;
   private boolean hasSetNotificationWillShowInForegroundHandler = false;
   private boolean hasSetRequiresPrivacyConsent = false;
@@ -157,7 +155,6 @@ public class OneSignalPlugin
     OneSignal.addEmailSubscriptionObserver(this);
     OneSignal.addPermissionObserver(this);
     OneSignal.setNotificationWillShowInForegroundHandler(this);
-    OneSignal.setNotificationOpenedHandler(this);
   }
 
   private void setLogLevel(MethodCall call, Result reply) {
@@ -337,11 +334,7 @@ public class OneSignalPlugin
   }
 
   private void initNotificationOpenedHandlerParams() {
-    this.hasSetNotificationOpenedHandler = true;
-    if (this.coldStartNotificationResult != null) {
-      this.notificationOpened(this.coldStartNotificationResult);
-      this.coldStartNotificationResult = null;
-    }
+    OneSignal.setNotificationOpenedHandler(this);
   }
 
   private void initInAppMessageClickedHandlerParams() {
@@ -403,11 +396,6 @@ public class OneSignalPlugin
 
   @Override
   public void notificationOpened(OSNotificationOpenedResult result) {
-    if (!this.hasSetNotificationOpenedHandler) {
-      this.coldStartNotificationResult = result;
-      return;
-    }
-
     try {
       invokeMethodOnUiThread("OneSignal#handleOpenedNotification", OneSignalSerializer.convertNotificationOpenResultToMap(result));
     } catch (JSONException e) {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -140,10 +140,11 @@ public class OneSignalPlugin
     String appId = call.argument("appId");
     Context context = flutterRegistrar.activeContext();
 
+    OneSignal.setInAppMessageClickHandler(this);
     OneSignal.initWithContext(context);
     OneSignal.setAppId(appId);
 
-    if (hasSetRequiresPrivacyConsent)
+    if (hasSetRequiresPrivacyConsent && !OneSignal.userProvidedPrivacyConsent())
       this.waitingForUserPrivacyConsent = true;
     else
       this.addObservers();
@@ -156,6 +157,7 @@ public class OneSignalPlugin
     OneSignal.addEmailSubscriptionObserver(this);
     OneSignal.addPermissionObserver(this);
     OneSignal.setNotificationWillShowInForegroundHandler(this);
+    OneSignal.setNotificationOpenedHandler(this);
   }
 
   private void setLogLevel(MethodCall call, Result reply) {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -106,7 +106,7 @@ class OneSignalSerializer {
 
         hash.put("androidNotificationId", notification.getAndroidNotificationId());
 
-        if (notification.getGroupedNotifications() != null) {
+        if (notification.getGroupedNotifications() != null && !notification.getGroupedNotifications().isEmpty()) {
             JSONArray payloadJsonArray = new JSONArray();
             for (OSNotification groupedNotification : notification.getGroupedNotifications())
                 payloadJsonArray.put(groupedNotification.toJSONObject());

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -77,6 +77,7 @@
 #pragma mark FlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
+    [OneSignal initWithLaunchOptions:nil];
     [OneSignal setMSDKType:@"flutter"];
 
     // Wrapper SDK's call init with no app ID early on in the
@@ -153,7 +154,6 @@
          [self handleInAppMessageClicked:action];
      }];
     
-    [OneSignal initWithLaunchOptions:nil];
     [OneSignal setAppId:call.arguments[@"appId"]];
 
     // If the user has required privacy consent, the SDK will not
@@ -292,7 +292,6 @@
 
 - (void)initNotificationOpenedHandlerParams {
     [OneSignal setNotificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
-        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"setNotificationOpenedHandler called from addObservers"];
         [OneSignalPlugin.sharedInstance handleNotificationOpened:result];
     }];
 }

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -292,11 +292,11 @@ class OSNotificationAction {
 
   /// The ID of the button on your notification
   /// that the user tapped
-  late String actionId;
+  String? actionId;
 
   OSNotificationAction(Map<String, dynamic> json) {
     this.type = OSNotificationActionType.opened;
-    this.actionId = json['id'] as String;
+    this.actionId = json['id'] as String?;
 
     if (json.containsKey('type'))
       this.type = OSNotificationActionType.values[json['type'] as int];


### PR DESCRIPTION
Fix Android handler 


* Add in-app message handler listener
* Fix grouped notification parsing, not add to JSON if is an empty array
* Fix action id, make it optional
* Add notification open handler listener

Fix iOS Notification open handler


* Add open handler listener
* Add cold start support --> Not working

On iOS notification, the open handler is not being called when the app is swiped away. 


## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/375)
<!-- Reviewable:end -->

