### PR TITLE
Fix launchUrl Android returning null

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -128,7 +128,7 @@ class OneSignalSerializer {
         if (notification.getSmallIconAccentColor() != null)
             hash.put("smallIconAccentColor", notification.getSmallIconAccentColor());
         if (notification.getLaunchURL() != null)
-            hash.put("launchURL", notification.getLaunchURL());
+            hash.put("launchUrl", notification.getLaunchURL());
         if (notification.getSound() != null)
             hash.put("sound", notification.getSound());
         if (notification.getLedColor() != null)


### PR DESCRIPTION
* Fix parsing issue, rename key from launchURL to launchUrl

Fixes 
https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/392

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/398)
<!-- Reviewable:end -->
