### PR TITLE
Release commit beta cut 4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '3.0.0-beta3'
+version '3.0.0-beta4'
 
 buildscript {
     repositories {
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    api 'com.onesignal:OneSignal:4.3.3'
+    api 'com.onesignal:OneSignal:4.4.0'
 }
 
 // Adds required manifestPlaceholders keys to allow mainifest merge gradle step to complete

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,7 +32,7 @@ target 'Runner' do
 end
 
 target 'OneSignalNotificationServiceExtension' do
-   pod 'OneSignal', '3.4.3'
+  pod 'OneSignalXCFramework', '3.4.4'
 end
 
 post_install do |installer|

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
     sdk: flutter
 
   onesignal_flutter:
-    path: ^3.0.0-beta3
+    path: ^3.0.0-beta4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '3.0.0-beta3'
+  s.version          = '3.0.0-beta4'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignal', '3.4.3'
+  s.dependency 'OneSignalXCFramework', '3.4.4'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 3.0.0-beta3
+version: 3.0.0-beta4
 author: Brad Hesse <brad@onesignal.com>, Josh Kasten <josh@onesignal.com>
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 


### PR DESCRIPTION
* Fix launch URL always returning null on Android https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/398
* Upgrade from Android version 4.3.3 to 4.4.0
  - See full release notes https://github.com/OneSignal/OneSignal-Android-SDK/releases
* Upgrade from iOS version 3.4.3 to 3.4.4
  - See full release notes https://github.com/OneSignal/OneSignal-iOS-SDK/releases
* Update pod file to use XCFramework

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/400)
<!-- Reviewable:end -->
