### PR TITLE
Fix serialization for grouped notification

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -135,7 +135,7 @@ class OneSignalSerializer {
             for (OSNotification groupedNotification : notification.getGroupedNotifications())
                 payloadJsonArray.put(groupedNotification.toJSONObject());
 
-            hash.put("groupedNotifications", payloadJsonArray);
+            hash.put("groupedNotifications", payloadJsonArray.toString());
         }
 
         hash.put("notificationId", notification.getNotificationId());

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -217,9 +217,10 @@ class OSNotification extends JSONStringRepresentable {
           json['backgroundImageLayout'].cast<String, dynamic>());
     }
     if (json.containsKey('groupedNotifications')) {
-      String jsonGroupedNotifications = json['groupedNotifications'] as String;
-      List jsonList = jsonDecode(jsonGroupedNotifications) as List;
-      this.groupedNotifications = jsonList.map((item) => OSNotification(item)).toList();
+      final dynamic jsonGroupedNotifications = json['groupedNotifications'];
+      final jsonList = jsonDecode(jsonGroupedNotifications.toString()) as List<dynamic>;
+      this.groupedNotifications = jsonList.map((dynamic item) =>
+          OSNotification(item as Map<String, dynamic>)).toList();
     }
     
     // shared parameters


### PR DESCRIPTION
See https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/377#issuecomment-868393081.

The problem is that it is not possible to pass the current content `groupedNotifications` through [MethodChannel](https://api.flutter.dev/flutter/services/MethodChannel-class.html). Pull request fixes crash when user clicks on grouped push notifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/423)
<!-- Reviewable:end -->
