### PR TITLE
Single response

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -248,11 +248,11 @@ public class OneSignalPlugin
     String email = call.argument("email");
     String emailAuthHashToken = call.argument("emailAuthHashToken");
 
-    OneSignal.setEmail(email, emailAuthHashToken, new OSFlutterEmailHandle(flutterRegistrar, channel, reply, "setEmail"));
+    OneSignal.setEmail(email, emailAuthHashToken, new OSFlutterEmailHandler(flutterRegistrar, channel, reply, "setEmail"));
   }
 
   private void logoutEmail(final Result reply) {
-    OneSignal.logoutEmail(new OSFlutterEmailHandle(flutterRegistrar, channel, reply, "logoutEmail"));
+    OneSignal.logoutEmail(new OSFlutterEmailHandler(flutterRegistrar, channel, reply, "logoutEmail"));
   }
 
   private void setSMSNumber(MethodCall call, final Result reply) {
@@ -396,10 +396,10 @@ public class OneSignalPlugin
     }
   }
 
-  static class OSFlutterEmailHandle extends OSFlutterHandler
+  static class OSFlutterEmailHandler extends OSFlutterHandler
           implements OneSignal.EmailUpdateHandler {
 
-    OSFlutterEmailHandle(PluginRegistry.Registrar flutterRegistrar, MethodChannel channel, Result res, String methodName) {
+    OSFlutterEmailHandler(PluginRegistry.Registrar flutterRegistrar, MethodChannel channel, Result res, String methodName) {
       super(flutterRegistrar, channel, res, methodName);
     }
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -160,6 +160,12 @@ public class OneSignalPlugin
   }
 
   private void addObservers() {
+    // Clean observers before setting, avoid being call twice
+    OneSignal.removeSubscriptionObserver(this);
+    OneSignal.removeEmailSubscriptionObserver(this);
+    OneSignal.removeSMSSubscriptionObserver(this);
+    OneSignal.removePermissionObserver(this);
+
     OneSignal.addSubscriptionObserver(this);
     OneSignal.addEmailSubscriptionObserver(this);
     OneSignal.addSMSSubscriptionObserver(this);


### PR DESCRIPTION
Add single response handler 

* Some calls might end being called twice from the native side. Even if we already cover this from the native side, add safe
check to avoid more than one call to the same flutter response

Clear handlers commit already approved, review commit "Add single response handler"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/445)
<!-- Reviewable:end -->
