### PR TITLE
Re-expose notificationPermissionStatus

### DIFF
--- a/lib/src/defines.dart
+++ b/lib/src/defines.dart
@@ -1,4 +1,4 @@
-String sdkVersion = "2.2.0";
+String sdkVersion = "3.1.0";
 
 /// Determines how notifications should be displayed
 enum OSNotificationDisplayType { none, alert, notification }
@@ -7,8 +7,13 @@ enum OSNotificationDisplayType { none, alert, notification }
 /// or took a specific action by tapping a button (`actionTaken`)
 enum OSNotificationActionType { opened, actionTaken }
 
-//// NOTE: provisional permission is only available in iOS 12
-enum OSNotificationPermission { notDetermined, denied, authorized, provisional }
+enum OSNotificationPermission {
+  notDetermined,
+  denied,
+  authorized,
+  provisional, // only available in iOS 12
+  ephemeral, // only available in iOS 14
+}
 
 /// An enum that declares different types of log levels you can
 /// use with the OneSignal SDK, going from the least verbose (none)

--- a/lib/src/permission.dart
+++ b/lib/src/permission.dart
@@ -96,6 +96,7 @@ class OSDeviceState extends JSONStringRepresentable {
   String? emailAddress;
   String? smsUserId;
   String? smsNumber;
+  OSNotificationPermission? notificationPermissionStatus;
 
   OSDeviceState(Map<String, dynamic> json) {
     this.hasNotificationPermission = json['hasNotificationPermission'] as bool;
@@ -109,6 +110,7 @@ class OSDeviceState extends JSONStringRepresentable {
     this.emailAddress = json['emailAddress'] as String?;
     this.smsUserId = json['smsUserId'] as String?;
     this.smsNumber = json['smsNumber'] as String?;
+    this.notificationPermissionStatus = json['notificationPermissionStatus'] == null ? null : OSNotificationPermission.values[json['notificationPermissionStatus']];
   }
 
   String jsonRepresentation() {
@@ -123,7 +125,8 @@ class OSDeviceState extends JSONStringRepresentable {
       'emailAddress': this.emailAddress,
       'isSMSSubscribed': this.smsSubscribed,
       'smsUserId': this.smsUserId,
-      'smsNumber': this.smsNumber
+      'smsNumber': this.smsNumber,
+      'notificationPermissionStatus': this.notificationPermissionStatus?.index,
     });
   }
 }


### PR DESCRIPTION
This was exposed in the past but appears to have been hidden with the 3.x refactor.

I also added OSNotificationPermission.ephemeral to match the underlying platform SDKs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/450)
<!-- Reviewable:end -->
