### PR TITLE
Feature app defined setLanguage

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -341,7 +341,7 @@ public class OneSignalPlugin
 
   private void setLanguage(MethodCall call, final Result result) {
     String language = call.argument("language");
-    if(language != null && language.length() == 0)
+    if (language != null && language.length() == 0)
       language = null;
 
       OneSignal.setLanguage(language);

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -120,6 +120,8 @@ public class OneSignalPlugin
       this.setExternalUserId(call, result);
     else if (call.method.contentEquals("OneSignal#removeExternalUserId"))
       this.removeExternalUserId(result);
+    else if (call.method.contentEquals("OneSignal#setLanguage"))
+      this.setLanguage(call, result);
     else if (call.method.contentEquals("OneSignal#initNotificationOpenedHandlerParams"))
       this.initNotificationOpenedHandlerParams();
     else if (call.method.contentEquals("OneSignal#initInAppMessageClickedHandlerParams"))
@@ -335,6 +337,14 @@ public class OneSignalPlugin
                 null);
       }
     });
+  }
+
+  private void setLanguage(MethodCall call, final Result result) {
+    String language = call.argument("language");
+    if(language != null && language.length() == 0)
+      language = null;
+
+      OneSignal.setLanguage(language);
   }
 
   private void setExternalUserId(MethodCall call, final Result result) {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,7 +32,7 @@ target 'Runner' do
 end
 
 target 'OneSignalNotificationServiceExtension' do
-  pod 'OneSignalXCFramework', '3.5.3'
+  pod 'OneSignalXCFramework', '3.6.0'
 end
 
 post_install do |installer|

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -142,6 +142,8 @@
         [self setExternalUserId:call withResult:result];
     else if ([@"OneSignal#removeExternalUserId" isEqualToString:call.method])
         [self removeExternalUserId:call withResult:result];
+    else if ([@"OneSignal#setLanguage" isEqualToString:call.method])
+        [self setLanguage:call withResult:result];
     else if ([@"OneSignal#initNotificationOpenedHandlerParams" isEqualToString:call.method])
         [self initNotificationOpenedHandlerParams];
     else if ([@"OneSignal#initInAppMessageClickedHandlerParams" isEqualToString:call.method])
@@ -318,6 +320,14 @@
         [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Remove external user id Failure with error: %@", error]];
         result(error.flutterError);
     }];
+}
+
+- (void)setLanguage:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    id language = call.arguments[@"language"];
+    if (language == [NSNull null])
+        language = nil;
+
+    [OneSignal setLanguage:language];
 }
 
 - (void)initNotificationOpenedHandlerParams {

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -324,8 +324,9 @@
 
 - (void)setLanguage:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     id language = call.arguments[@"language"];
-    if (language == [NSNull null])
+    if (language == [NSNull null]) {
         language = nil;
+    }
 
     [OneSignal setLanguage:language];
 }

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '3.5.3'
+  s.dependency 'OneSignalXCFramework', '3.6.0'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -329,6 +329,12 @@ class OneSignal {
     return results.cast<String, dynamic>();
   }
 
+  Future<Map<String, dynamic>> setLanguage(String language) async {
+    Map<dynamic, dynamic> results =
+        await (_channel.invokeMethod("OneSignal#setLanguage", {'language' : language}));
+    return results.cast<String, dynamic>();
+  }
+
   /// Adds a single key, value trigger, which will trigger an in app message
   /// if one exists matching the specific trigger added
   Future<void> addTrigger(String key, Object value) async {

--- a/test/mock_channel.dart
+++ b/test/mock_channel.dart
@@ -67,6 +67,9 @@ class OneSignalMockChannelController {
       case "OneSignal#removeExternalUserId":
         this.state.externalId = null;
         return {"success" : true};
+      case "OneSignal#setLanguage":
+      this.state.language = (call.arguments as Map<dynamic, dynamic>)['language'] as String?;;
+      return {"success" : true};
     }
   }
 }
@@ -93,6 +96,7 @@ class OneSignalState {
   OSNotificationDisplayType? inFocusDisplayType;
   bool? disablePush;
   String? externalId;
+  String? language;
 
   // tags
   Map<dynamic, dynamic>? tags;

--- a/test/mock_channel.dart
+++ b/test/mock_channel.dart
@@ -68,7 +68,7 @@ class OneSignalMockChannelController {
         this.state.externalId = null;
         return {"success" : true};
       case "OneSignal#setLanguage":
-        this.state.language = (call.arguments as Map<dynamic, dynamic>)['language'] as String?;;
+        this.state.language = (call.arguments as Map<dynamic, dynamic>)['language'] as String?;
         return {"success" : true};
     }
   }

--- a/test/mock_channel.dart
+++ b/test/mock_channel.dart
@@ -68,8 +68,8 @@ class OneSignalMockChannelController {
         this.state.externalId = null;
         return {"success" : true};
       case "OneSignal#setLanguage":
-      this.state.language = (call.arguments as Map<dynamic, dynamic>)['language'] as String?;;
-      return {"success" : true};
+        this.state.language = (call.arguments as Map<dynamic, dynamic>)['language'] as String?;;
+        return {"success" : true};
     }
   }
 }

--- a/test/onesignalflutter_test.dart
+++ b/test/onesignalflutter_test.dart
@@ -109,4 +109,11 @@ void main() {
       expect(channelController.state.externalId, null);
     }));
   });
+
+  //Set Language test
+  test('setting language', () {
+    onesignal.setLanguage('fr').then(expectAsync1((v) {
+      expect(channelController.state.language, 'fr');
+    }));
+  });
 }


### PR DESCRIPTION
# Description
## Line Summary
Add feature app-defined language implementation to OneSignal-Flutter-SDK. A user can define their own language setting to be used by OneSignal-SDK

## Details
* Add `setLanguage` method to OneSignal Android plugin 
* Add `setLanguage` method to OneSignal iOS plugin
* Update Podfile and onesignal_flutter.podspec files with `OneSignalXCFramework 3.6.0`
* Add `setLanguage` bridge methods to onesignal_flutter.dart

## Test
* Test device using button click to call _handleSetLanguage to set it to language different from language defined by the app. OneSignal app dashboard reflects the language set using OneSignal.setLanguage
* Add unit test defining 'fr' using `setLanguage` callback that expects `language` returned to be the same

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/452)
<!-- Reviewable:end -->
