### PR TITLE
Remove path from pubspec.yaml, it isn't valid

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,8 +16,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  onesignal_flutter:
-    path: ^3.1.0
+  onesignal_flutter: ^3.1.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
* Path results in pub not being able to find the onesignal_flutter package.
* Fixes the following error
   - pub get failed (66; Because onesignal_example depends on onesignal_flutter from path which doesn't exist (could not find package onesignal_flutter at "^3.1.0"), version solving failed.)
* Tested with Flutter 2.2.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/456)
<!-- Reviewable:end -->
