### PR TITLE
Rename properties to `isSubscribed` and `isPushDisabled`

### DIFF
--- a/lib/src/permission.dart
+++ b/lib/src/permission.dart
@@ -86,8 +86,8 @@ class OSPermissionStateChanges extends JSONStringRepresentable {
 class OSDeviceState extends JSONStringRepresentable {
 
   bool hasNotificationPermission = false;
-  bool pushDisabled = false;
-  bool subscribed = false;
+  bool isPushDisabled = false;
+  bool isSubscribed = false;
   bool emailSubscribed = false;
   bool smsSubscribed = false;
   String? userId;
@@ -100,8 +100,8 @@ class OSDeviceState extends JSONStringRepresentable {
 
   OSDeviceState(Map<String, dynamic> json) {
     this.hasNotificationPermission = json['hasNotificationPermission'] as bool;
-    this.pushDisabled = json['pushDisabled'] as bool;
-    this.subscribed = json['subscribed'] as bool;
+    this.isPushDisabled = json['isPushDisabled'] as bool;
+    this.isSubscribed = json['isSubscribed'] as bool;
     this.emailSubscribed = json['emailSubscribed'] as bool;
     this.smsSubscribed = json['smsSubscribed'] as bool;
     this.userId = json['userId'] as String?;
@@ -116,8 +116,8 @@ class OSDeviceState extends JSONStringRepresentable {
   String jsonRepresentation() {
     return convertToJsonString({
       'hasNotificationPermission': this.hasNotificationPermission,
-      'isPushDisabled': this.pushDisabled,
-      'isSubscribed': this.subscribed,
+      'isPushDisabled': this.isPushDisabled,
+      'isSubscribed': this.isSubscribed,
       'userId': this.userId,
       'pushToken': this.pushToken,
       'isEmailSubscribed': this.emailSubscribed,

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -4,13 +4,13 @@ import 'package:onesignal_flutter/src/utils.dart';
 class OSSubscriptionState extends JSONStringRepresentable {
   /// Indicates if you have ever called setSubscription(false) to
   /// programmatically disable notifications for this user
-  bool userSubscriptionSetting = false;
+  bool isPushDisabled = false;
 
   /// A boolean parameter that indicates if the  user
   /// is subscribed to your app with OneSignal
   /// This is only true if the `userId`, `pushToken`, and
-  /// `userSubscriptionSetting` parameters are defined/true.
-  bool subscribed = false;
+  /// `isPushDisabled` parameters are defined/true.
+  bool isSubscribed = false;
 
   /// The current user's User ID (AKA playerID) with OneSignal
   String? userId; //the user's 'playerId' on OneSignal
@@ -19,8 +19,8 @@ class OSSubscriptionState extends JSONStringRepresentable {
   String? pushToken;
 
   OSSubscriptionState(Map<String, dynamic> json) {
-    this.subscribed = json['subscribed'] as bool;
-    this.userSubscriptionSetting = json['userSubscriptionSetting'] as bool;
+    this.isSubscribed = json['isSubscribed'] as bool;
+    this.isPushDisabled = json['isPushDisabled'] as bool;
 
     if (json.containsKey('userId')) this.userId = json['userId'] as String?;
     if (json.containsKey('pushToken'))
@@ -29,8 +29,8 @@ class OSSubscriptionState extends JSONStringRepresentable {
 
   String jsonRepresentation() {
     return convertToJsonString({
-      'subscribed': this.subscribed,
-      'userSubscriptionSetting': this.userSubscriptionSetting,
+      'isSubscribed': this.isSubscribed,
+      'isPushDisabled': this.isPushDisabled,
       'pushToken': this.pushToken,
       'userId': this.userId
     });

--- a/test.json
+++ b/test.json
@@ -1,14 +1,14 @@
 {
    "subscription_changed_test" : {
       "from": {
-         "subscribed": false,  
-         "userSubscriptionSetting": true,  
+         "isSubscribed": false,  
+         "isPushDisabled": true,  
          "pushToken": "07afbb0b4cb6e7ae5e81efc7fd5d35267ea9a4f12120045aebe29945e52ea30e",  
          "userId": null
       },
       "to": {  
-         "subscribed": true,  
-         "userSubscriptionSetting": true,  
+         "isSubscribed": true,  
+         "isPushDisabled": true,  
          "pushToken": "07afbb0b4cb6e7ae5e81efc7fd5d35267ea9a4f12120045aebe29945e52ea30e",  
          "userId": "c1b395fc-3b17-4c18-aaa6-195cd3461311"
       }

--- a/test/subscription_test.dart
+++ b/test/subscription_test.dart
@@ -23,13 +23,13 @@ void main() {
         subscriptionChanges.to.pushToken, subscriptionChanges.from.pushToken);
   });
 
-  test('expect subscription correctly parses `subscribed`', () {
-    expect(subscriptionChanges.to.subscribed,
-        !subscriptionChanges.from.subscribed);
+  test('expect subscription correctly parses `isSubscribed`', () {
+    expect(subscriptionChanges.to.isSubscribed,
+        !subscriptionChanges.from.isSubscribed);
   });
 
-  test('expect subscription correctly parses `userSubscriptionSetting`', () {
-    expect(subscriptionChanges.to.userSubscriptionSetting, true);
+  test('expect subscription correctly parses `isPushDisabled`', () {
+    expect(subscriptionChanges.to.isPushDisabled, true);
   });
 
   // Email Subscription State Tests


### PR DESCRIPTION
Renaming Subscription State properties from:
- `subscribed` to `isSubscribed`
- `userSubscriptionSetting` to `isPushDisabled`
- This was not issue on latest 2.x.x Flutter SDK (2.6.4 at time of writing, using Android SDK 3.16.0) which uses the old key names
- This is needed because those are used in the JSON sent from the `DeviceState` after Android SDK 4.x.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/463)
<!-- Reviewable:end -->
