### PR TITLE
Android plugin API updated to support v2 Embedding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,12 @@
 pubspec.lock
 
 build/
-.idea/
 android/.idea
+.flutter-plugins-dependencies
+flutter_export_environment.sh
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/

--- a/android/src/main/java/com/onesignal/flutter/FlutterRegistrarResponder.java
+++ b/android/src/main/java/com/onesignal/flutter/FlutterRegistrarResponder.java
@@ -1,5 +1,6 @@
 package com.onesignal.flutter;
 
+import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -7,12 +8,14 @@ import com.onesignal.OneSignal;
 
 import java.util.HashMap;
 
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
 
 abstract class FlutterRegistrarResponder {
+   Context context;
    MethodChannel channel;
-   PluginRegistry.Registrar flutterRegistrar;
+   BinaryMessenger messenger;
 
    /**
     * MethodChannel class is home to success() method used by Result class

--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessagingController.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessagingController.java
@@ -5,6 +5,7 @@ import com.onesignal.OneSignal;
 import java.util.Collection;
 import java.util.Map;
 
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -14,11 +15,11 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 public class OneSignalInAppMessagingController extends FlutterRegistrarResponder implements MethodCallHandler {
     private MethodChannel channel;
 
-    static void registerWith(Registrar registrar) {
+    static void registerWith(BinaryMessenger messenger) {
         OneSignalInAppMessagingController controller = new OneSignalInAppMessagingController();
-        controller.channel = new MethodChannel(registrar.messenger(), "OneSignal#inAppMessages");
+        controller.messenger = messenger;
+        controller.channel = new MethodChannel(messenger, "OneSignal#inAppMessages");
         controller.channel.setMethodCallHandler(controller);
-        controller.flutterRegistrar = registrar;
     }
 
     @Override

--- a/android/src/main/java/com/onesignal/flutter/OneSignalOutcomeEventsController.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalOutcomeEventsController.java
@@ -6,6 +6,7 @@ import com.onesignal.OSOutcomeEvent;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -21,8 +22,8 @@ class OSFlutterOutcomeEventsHandler extends FlutterRegistrarResponder implements
     // this property guarantees the callback will never be called more than once.
     private AtomicBoolean replySubmitted = new AtomicBoolean(false);
 
-    OSFlutterOutcomeEventsHandler(PluginRegistry.Registrar flutterRegistrar, MethodChannel channel, Result result) {
-        this.flutterRegistrar = flutterRegistrar;
+    OSFlutterOutcomeEventsHandler(BinaryMessenger messenger, MethodChannel channel, Result result) {
+        this.messenger = messenger;
         this.channel = channel;
         this.result = result;
     }
@@ -42,14 +43,12 @@ class OSFlutterOutcomeEventsHandler extends FlutterRegistrarResponder implements
 
 public class OneSignalOutcomeEventsController extends FlutterRegistrarResponder implements MethodCallHandler {
     private MethodChannel channel;
-    private Registrar registrar;
 
-    static void registerWith(Registrar registrar) {
+    static void registerWith(BinaryMessenger messenger) {
         OneSignalOutcomeEventsController controller = new OneSignalOutcomeEventsController();
-        controller.registrar = registrar;
-        controller.channel = new MethodChannel(registrar.messenger(), "OneSignal#outcomes");
+        controller.messenger = messenger;
+        controller.channel = new MethodChannel(messenger, "OneSignal#outcomes");
         controller.channel.setMethodCallHandler(controller);
-        controller.flutterRegistrar = registrar;
     }
 
     @Override
@@ -72,7 +71,7 @@ public class OneSignalOutcomeEventsController extends FlutterRegistrarResponder 
             return;
         }
 
-        OneSignal.sendOutcome(name, new OSFlutterOutcomeEventsHandler(registrar, channel, result));
+        OneSignal.sendOutcome(name, new OSFlutterOutcomeEventsHandler(messenger, channel, result));
     }
 
     private void sendUniqueOutcome(MethodCall call, Result result) {
@@ -83,7 +82,7 @@ public class OneSignalOutcomeEventsController extends FlutterRegistrarResponder 
             return;
         }
 
-        OneSignal.sendUniqueOutcome(name, new OSFlutterOutcomeEventsHandler(registrar, channel, result));
+        OneSignal.sendUniqueOutcome(name, new OSFlutterOutcomeEventsHandler(messenger, channel, result));
     }
 
     private void sendOutcomeWithValue(MethodCall call, Result result) {
@@ -100,7 +99,7 @@ public class OneSignalOutcomeEventsController extends FlutterRegistrarResponder 
             return;
         }
 
-        OneSignal.sendOutcomeWithValue(name, value.floatValue(), new OSFlutterOutcomeEventsHandler(registrar, channel, result));
+        OneSignal.sendOutcomeWithValue(name, value.floatValue(), new OSFlutterOutcomeEventsHandler(messenger, channel, result));
     }
 
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalTagsController.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalTagsController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -30,8 +31,8 @@ class OSFlutterChangeTagsHandler extends FlutterRegistrarResponder implements Ch
     // this property guarantees the callback will never be called more than once.
     private AtomicBoolean replySubmitted = new AtomicBoolean(false);
 
-    OSFlutterChangeTagsHandler(PluginRegistry.Registrar flutterRegistrar, MethodChannel channel, Result res) {
-        this.flutterRegistrar = flutterRegistrar;
+    OSFlutterChangeTagsHandler(BinaryMessenger messenger, MethodChannel channel, Result res) {
+        this.messenger = messenger;
         this.channel = channel;
         this.result = res;
     }
@@ -71,14 +72,12 @@ class OSFlutterChangeTagsHandler extends FlutterRegistrarResponder implements Ch
 
 public class OneSignalTagsController extends FlutterRegistrarResponder implements MethodCallHandler {
     private MethodChannel channel;
-    private Registrar registrar;
 
-    static void registerWith(Registrar registrar) {
+    static void registerWith(BinaryMessenger messenger) {
         OneSignalTagsController controller = new OneSignalTagsController();
-        controller.registrar = registrar;
-        controller.channel = new MethodChannel(registrar.messenger(), "OneSignal#tags");
+        controller.messenger = messenger;
+        controller.channel = new MethodChannel(messenger, "OneSignal#tags");
         controller.channel.setMethodCallHandler(controller);
-        controller.flutterRegistrar = registrar;
     }
 
     @Override
@@ -94,14 +93,14 @@ public class OneSignalTagsController extends FlutterRegistrarResponder implement
     }
 
     private void getTags(MethodCall call, Result result) {
-        OneSignal.getTags(new OSFlutterChangeTagsHandler(registrar, channel, result));
+        OneSignal.getTags(new OSFlutterChangeTagsHandler(messenger, channel, result));
     }
 
     private void sendTags(MethodCall call, Result result) {
         // call.arguments is being casted to a Map<String, Object> so a try-catch with
         //  a ClassCastException will be thrown
         try {
-            OneSignal.sendTags(new JSONObject((Map<String, Object>) call.arguments), new OSFlutterChangeTagsHandler(registrar, channel, result));
+            OneSignal.sendTags(new JSONObject((Map<String, Object>) call.arguments), new OSFlutterChangeTagsHandler(messenger, channel, result));
         } catch(ClassCastException e) {
             replyError(result, "OneSignal", "sendTags failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }
@@ -111,7 +110,7 @@ public class OneSignalTagsController extends FlutterRegistrarResponder implement
         // call.arguments is being casted to a List<String> so a try-catch with
         //  a ClassCastException will be thrown
         try {
-            OneSignal.deleteTags((List<String>) call.arguments, new OSFlutterChangeTagsHandler(registrar, channel, result));
+            OneSignal.deleteTags((List<String>) call.arguments, new OSFlutterChangeTagsHandler(messenger, channel, result));
         } catch(ClassCastException e) {
             replyError(result, "OneSignal", "deleteTags failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -7,3 +7,5 @@
 build/
 
 .flutter-plugins
+.flutter-plugins-dependencies
+flutter_export_environment.sh

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="onesignal_example"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -29,17 +28,32 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
+            <!-- Specifies an Android theme to apply to this Activity as soon as
+                 the Android process has started. This theme is visible to the user
+                 while the Flutter UI initializes. After that, this theme continues
+                 to determine the Window background behind the Flutter UI. -->
             <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+                />
+            <!-- Displays an Android View that continues showing the launch screen
+                 Drawable until Flutter paints its first frame, then this splash
+                 screen fades out. A splash screen is useful to avoid any visual
+                 gap between the end of Android's launch screen and the painting of
+                 Flutter's first frame. -->
+            <meta-data
+                android:name="io.flutter.embedding.android.SplashScreenDrawable"
+                android:resource="@drawable/launch_background"
+                />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/example/android/app/src/main/java/com/onesignal/onesignalexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/onesignal/onesignalexample/MainActivity.java
@@ -1,13 +1,6 @@
 package com.onesignal.onesignalexample;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
 }

--- a/example/android/app/src/main/res/values/styles.xml
+++ b/example/android/app/src/main/res/values/styles.xml
@@ -5,4 +5,7 @@
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">@android:color/white</item>
+    </style>
 </resources>


### PR DESCRIPTION
As requested here [Issue 480](https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/480), it's necessary to update the Android implementation to support the v2 Embedding which it's the default for new Android plugins and it is highly recommended to be update it because future release of Flutter will fail to build with deprecated Android embedding.
I migrated the Android implementation to support embedding v2 while remaining compatible with apps that don’t use the v2 Android embedding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/486)
<!-- Reviewable:end -->
