### PR TITLE
adding relevanceScore and interruptionLevel to Notification.dart

### DIFF
--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '3.7.0'
+  s.dependency 'OneSignalXCFramework', '3.8.0'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -85,6 +85,16 @@ class OSNotification extends JSONStringRepresentable {
   /// The subtitle of the notification
   String? subtitle;
 
+  /// (iOS Only)
+  /// value between 0 and 1 for sorting notifications in a notification summary
+  double? relevanceScore;
+
+  /// (iOS Only)
+  /// The interruption level for the notification. This controls how the
+  /// notification will be displayed to the user if they are using focus modes
+  /// or notification summaries
+  String? interruptionLevel;
+
   /// (Android Only)
   /// Summary notifications grouped
   /// Notification payload will have the most recent notification received.
@@ -186,6 +196,10 @@ class OSNotification extends JSONStringRepresentable {
       this.subtitle = json['subtitle'] as String?;
     if (json.containsKey('attachments'))
       this.attachments = json['attachments'].cast<String, dynamic>();
+    if (json.containsKey('relevanceScore'))
+      this.relevanceScore = json['relevanceScore'] as double?;
+    if (json.containsKey('interruptionLevel'))
+      this.interruptionLevel = json['interruptionLevel'] as String?;
 
     // Android Specific Parameters
     if (json.containsKey("smallIcon"))


### PR DESCRIPTION
iOS 15 notification properties are now available in the iOS native SDK. This PR adds the properties to the Flutter OSNotification object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/489)
<!-- Reviewable:end -->
