### PR TITLE
Release 3.2.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '3.2.6'
+version '3.2.7'
 
 buildscript {
     repositories {

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '3.2.6'
+  s.version          = '3.2.7'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '3.9.0'
+  s.dependency 'OneSignalXCFramework', '3.9.1'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/lib/src/defines.dart
+++ b/lib/src/defines.dart
@@ -1,4 +1,4 @@
-String sdkVersion = "3.2.6";
+String sdkVersion = "3.2.7";
 
 /// Determines how notifications should be displayed
 enum OSNotificationDisplayType { none, alert, notification }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 3.2.6
+version: 3.2.7
 author: Brad Hesse <brad@onesignal.com>, Josh Kasten <josh@onesignal.com>
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 


### PR DESCRIPTION
- update iOS to [3.9.1 ](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.9.1) which adds back architectures to OneSignalXCFramework

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/511)
<!-- Reviewable:end -->
