### PR TITLE
Add missing fallbackToSettings argument on native iOS side

### DIFF
--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -202,9 +202,10 @@
 }
 
 - (void)promptPermission:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL fallbackToSettings = [call.arguments[@"fallback"] boolValue];
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         result(@(accepted));
-    }];
+    } fallbackToSettings:fallbackToSettings];
 }
 
 - (void)getDeviceState:(FlutterMethodCall *)call withResult:(FlutterResult)result {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/523)
<!-- Reviewable:end -->
