### PR TITLE
Fix CI issue

### DIFF
--- a/test/mock_channel.dart
+++ b/test/mock_channel.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:onesignal_flutter/onesignal_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /*
   This class mocks an iOS or Android host device


### PR DESCRIPTION
I noticed the last commit ba9eca1 resulted in a broken build; this is because `MethodChannel.setMockMethodCallHandler` was replaced by `TestDefaultBinaryMessenger.setMockMethodCallHandler` ([ref](https://docs.flutter.dev/release/breaking-changes/mock-platform-channels#description-of-change)). The migration guide indicated that a specific package needed to be imported so the test could behave as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/524)
<!-- Reviewable:end -->
