### PR TITLE
Add in app mesage lifecycle handler

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -59,11 +59,6 @@ public class OneSignalPlugin
   private boolean hasSetRequiresPrivacyConsent = false;
   private boolean waitingForUserPrivacyConsent = false;
 
-  private OSInAppMessage inAppMessage;
-  private boolean hasSetOnWillDisplayInAppMessageHandler = false;
-  private boolean hasSetOnDidDisplayInAppMessageHandler = false;
-  private boolean hasSetOnWillDismissInAppMessageHandler = false;
-  private boolean hasSetOnDidDismissInAppMessageHandler = false;
 
   private final HashMap<String, OSNotificationReceivedEvent> notificationReceivedEventCache = new HashMap<>();
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -168,14 +168,6 @@ public class OneSignalPlugin
       this.initNotificationOpenedHandlerParams();
     else if (call.method.contentEquals("OneSignal#initInAppMessageClickedHandlerParams"))
       this.initInAppMessageClickedHandlerParams();
-    else if (call.method.contentEquals("OneSignal#onWillDisplayInAppMessageHandlerParams"))
-      this.OnWillDisplayInAppMessageHandlerParams();
-    else if (call.method.contentEquals("OneSignal#onDidDisplayInAppMessageHandlerParams"))
-      this.OnDidDisplayInAppMessageHandlerParams();  
-    else if (call.method.contentEquals("OneSignal#onWillDismissInAppMessageHandlerParams"))
-      this.OnWillDismissInAppMessageHandlerParams();  
-    else if (call.method.contentEquals("OneSignal#onDidDismissInAppMessageHandlerParams"))
-      this.OnDidDismissInAppMessageHandlerParams();  
     else if (call.method.contentEquals("OneSignal#initNotificationWillShowInForegroundHandlerParams"))
       this.initNotificationWillShowInForegroundHandlerParams();
     else if (call.method.contentEquals("OneSignal#completeNotification"))
@@ -427,96 +419,28 @@ public class OneSignalPlugin
   }
 
   /* in app message lifecycle */
-  private void OnWillDisplayInAppMessageHandlerParams() {
-    this.hasSetOnWillDisplayInAppMessageHandler = true;
-    if(this.inAppMessage != null) {
-        this.onWillDisplayInAppMessageFlutter(this.inAppMessage);
-        this.inAppMessage = null;
-    }
-  }
-
-  private void OnDidDisplayInAppMessageHandlerParams() {
-      this.hasSetOnDidDisplayInAppMessageHandler = true;
-      if(this.inAppMessage != null) {
-          this.onDidDisplayInAppMessageFlutter(this.inAppMessage);
-          this.inAppMessage = null;
-      }
-  }
-
-  private void OnWillDismissInAppMessageHandlerParams() {
-      this.hasSetOnWillDismissInAppMessageHandler = true;
-      if(this.inAppMessage != null) {
-          this.onWillDismissInAppMessageFlutter(this.inAppMessage);
-          this.inAppMessage = null;
-      }
-  }
-
-  private void OnDidDismissInAppMessageHandlerParams() {
-      this.hasSetOnDidDismissInAppMessageHandler = true;
-      if(this.inAppMessage != null) {
-          this.onDidDismissInAppMessageFlutter(this.inAppMessage);
-          this.inAppMessage = null;
-      }
-  }
-
   public void setInAppMessageLifecycleHandler() {
     OneSignal.setInAppMessageLifecycleHandler(new OSInAppMessageLifecycleHandler() {
         @Override
         public void onWillDisplayInAppMessage(OSInAppMessage message) { 
-          onWillDisplayInAppMessageFlutter(message);
+          invokeMethodOnUiThread("OneSignal#onWillDisplayInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
         }
 
         @Override
         public void onDidDisplayInAppMessage(OSInAppMessage message) {
-          onDidDisplayInAppMessageFlutter(message);
+          invokeMethodOnUiThread("OneSignal#onDidDisplayInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
         }
 
         @Override
         public void onWillDismissInAppMessage(OSInAppMessage message) {
-          onWillDismissInAppMessageFlutter(message);
+          invokeMethodOnUiThread("OneSignal#onWillDismissInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
         }
 
         @Override
         public void onDidDismissInAppMessage(OSInAppMessage message) {
-          onDidDismissInAppMessageFlutter(message);
+          invokeMethodOnUiThread("OneSignal#onDidDismissInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
         }
     });
-  }
-
-  public void onWillDisplayInAppMessageFlutter(OSInAppMessage message) {
-    if (!this.hasSetOnWillDisplayInAppMessageHandler) {
-      this.inAppMessage = message;
-      return;
-    }
-    
-    invokeMethodOnUiThread("OneSignal#onWillDisplayInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
-  }
-
-  public void onDidDisplayInAppMessageFlutter(OSInAppMessage message) {
-    if (!this.hasSetOnDidDisplayInAppMessageHandler) {
-      this.inAppMessage = message;
-      return;
-    }
-      
-    invokeMethodOnUiThread("OneSignal#onDidDisplayInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
-  }
-
-  public void onWillDismissInAppMessageFlutter(OSInAppMessage message) {
-    if (!this.hasSetOnWillDismissInAppMessageHandler) {
-      this.inAppMessage = message;
-      return;
-    }
-
-    invokeMethodOnUiThread("OneSignal#onWillDismissInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
-  }
-
-  public void onDidDismissInAppMessageFlutter(OSInAppMessage message) {
-    if (!this.hasSetOnDidDismissInAppMessageHandler) {
-      this.inAppMessage = message;
-      return;
-    }
-      
-    invokeMethodOnUiThread("OneSignal#onDidDismissInAppMessage", OneSignalSerializer.convertInAppMessageToMap(message));
   }
 
   @Override

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -171,11 +171,11 @@ public class OneSignalPlugin
     else if (call.method.contentEquals("OneSignal#onWillDisplayInAppMessageHandlerParams"))
       this.OnWillDisplayInAppMessageHandlerParams();
     else if (call.method.contentEquals("OneSignal#onDidDisplayInAppMessageHandlerParams"))
-      this.OnWillDisplayInAppMessageHandlerParams();  
+      this.OnDidDisplayInAppMessageHandlerParams();  
     else if (call.method.contentEquals("OneSignal#onWillDismissInAppMessageHandlerParams"))
-      this.OnWillDisplayInAppMessageHandlerParams();  
+      this.OnWillDismissInAppMessageHandlerParams();  
     else if (call.method.contentEquals("OneSignal#onDidDismissInAppMessageHandlerParams"))
-      this.OnWillDisplayInAppMessageHandlerParams();  
+      this.OnDidDismissInAppMessageHandlerParams();  
     else if (call.method.contentEquals("OneSignal#initNotificationWillShowInForegroundHandlerParams"))
       this.initNotificationWillShowInForegroundHandlerParams();
     else if (call.method.contentEquals("OneSignal#completeNotification"))

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -6,6 +6,7 @@ import com.onesignal.OSDeviceState;
 import com.onesignal.OSEmailSubscriptionState;
 import com.onesignal.OSEmailSubscriptionStateChanges;
 import com.onesignal.OSInAppMessageAction;
+import com.onesignal.OSInAppMessage;
 import com.onesignal.OSNotification;
 import com.onesignal.OSNotificationAction;
 import com.onesignal.OSNotificationOpenedResult;
@@ -228,6 +229,14 @@ class OneSignalSerializer {
         hash.put("click_url", action.getClickUrl());
         hash.put("first_click", action.isFirstClick());
         hash.put("closes_message", action.doesCloseMessage());
+
+        return hash;
+    }
+
+    static HashMap<String, Object> convertInAppMessageToMap(OSInAppMessage message) {
+        HashMap<String, Object> hash = new HashMap<>();
+
+        hash.put("message_id", message.getMessageId());
 
         return hash;
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -83,6 +83,22 @@ class _MyAppState extends State<MyApp> {
       print("SMS SUBSCRIPTION STATE CHANGED ${changes.jsonRepresentation()}");
     });
 
+    OneSignal.shared.setOnWillDisplayInAppMessageHandler((message) {
+      print("ON WILL DISPLAY IN APP MESSAGE ${message.messageId}");
+    });
+
+    OneSignal.shared.setOnDidDisplayInAppMessageHandler((message) {
+      print("ON DID DISPLAY IN APP MESSAGE ${message.messageId}");
+    });
+
+    OneSignal.shared.setOnWillDismissInAppMessageHandler((message) {
+      print("ON WILL DISMISS IN APP MESSAGE ${message.messageId}");
+    });
+
+    OneSignal.shared.setOnDidDismissInAppMessageHandler((message) {
+      print("ON DID DISMISS IN APP MESSAGE ${message.messageId}");
+    });
+
     // NOTE: Replace with your own app ID from https://www.onesignal.com
     await OneSignal.shared
         .setAppId("380dc082-5231-4cc2-ab51-a03da5a0e4c2");

--- a/ios/Classes/OSFlutterCategories.h
+++ b/ios/Classes/OSFlutterCategories.h
@@ -43,6 +43,10 @@
 - (NSDictionary *)toJson;
 @end
 
+@interface OSInAppMessage (Flutter)
+- (NSDictionary *)toJson;
+@end
+
 @interface NSError (Flutter)
 - (FlutterError *)flutterError;
 @end

--- a/ios/Classes/OSFlutterCategories.m
+++ b/ios/Classes/OSFlutterCategories.m
@@ -97,6 +97,16 @@
 }
 @end
 
+@implementation OSInAppMessage (Flutter)
+- (NSDictionary *)toJson {
+    NSMutableDictionary *json = [NSMutableDictionary new];
+
+    json[@"message_id"] = self.messageId;
+
+    return json;
+}
+@end
+
 @implementation NSError (Flutter)
 - (FlutterError *)flutterError {
     return [FlutterError errorWithCode:[NSString stringWithFormat:@"%i", (int)self.code] message:self.localizedDescription details:nil];

--- a/ios/Classes/OneSignalPlugin.h
+++ b/ios/Classes/OneSignalPlugin.h
@@ -28,7 +28,7 @@
 #import <Flutter/Flutter.h>
 #import <OneSignal/OneSignal.h>
 
-@interface OneSignalPlugin : NSObject<FlutterPlugin, OSSubscriptionObserver, OSPermissionObserver, OSEmailSubscriptionObserver, OSSMSSubscriptionObserver>
+@interface OneSignalPlugin : NSObject<FlutterPlugin, OSSubscriptionObserver, OSPermissionObserver, OSEmailSubscriptionObserver, OSSMSSubscriptionObserver, OSInAppMessageLifecycleHandler>
 
 // Do NOT initialize instances of this class.
 // You must only reference the shared instance.

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -55,13 +55,6 @@
 
 @property (strong, nonatomic) NSMutableDictionary* notificationCompletionCache;
 @property (strong, nonatomic) NSMutableDictionary* receivedNotificationCache;
-
-@property (atomic) BOOL hasSetOnWillDisplayInAppMessageHandler;
-@property (atomic) BOOL hasSetOnDidDisplayInAppMessageHandler;
-@property (atomic) BOOL hasSetOnWillDismissInAppMessageHandler;
-@property (atomic) BOOL hasSetOnDidDismissInAppMessageHandler;
-
-@property (strong, nonatomic) OSInAppMessage *inAppMessage;
 @end
 
 @implementation OneSignalPlugin
@@ -76,10 +69,6 @@
         sharedInstance.notificationCompletionCache = [NSMutableDictionary new];;
         sharedInstance.hasSetInAppMessageClickedHandler = false;
         sharedInstance.hasSetNotificationWillShowInForegroundHandler = false;
-        sharedInstance.hasSetOnWillDisplayInAppMessageHandler = false;
-        sharedInstance.hasSetOnDidDisplayInAppMessageHandler = false;
-        sharedInstance.hasSetOnWillDismissInAppMessageHandler = false;
-        sharedInstance.hasSetOnDidDismissInAppMessageHandler = false;
     });
     return sharedInstance;
 }
@@ -162,14 +151,6 @@
         [self initNotificationWillShowInForegroundHandlerParams];
     else if ([@"OneSignal#completeNotification" isEqualToString:call.method])
         [self completeNotification:call withResult:result];
-    else if ([@"OneSignal#onWillDisplayInAppMessageHandlerParams" isEqualToString:call.method])
-        [self onWillDisplayInAppMessageHandlerParams];
-    else if ([@"OneSignal#onDidDisplayInAppMessageHandlerParams" isEqualToString:call.method])
-        [self onDidDisplayInAppMessageHandlerParams];
-    else if ([@"OneSignal#onWillDismissInAppMessageHandlerParams" isEqualToString:call.method])
-        [self onWillDismissInAppMessageHandlerParams];
-    else if ([@"OneSignal#onDidDismissInAppMessageHandlerParams" isEqualToString:call.method])
-        [self onDidDismissInAppMessageHandlerParams];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -178,10 +159,10 @@
      [OneSignal setInAppMessageClickHandler:^(OSInAppMessageAction *action) {
          [self handleInAppMessageClicked:action];
      }];
-
-    [OneSignal setInAppMessageLifecycleHandler:self];
     
     [OneSignal setAppId:call.arguments[@"appId"]];
+
+    [OneSignal setInAppMessageLifecycleHandler: self];
 
     // If the user has required privacy consent, the SDK will not
     // add these observers. So we should delay adding the observers
@@ -417,43 +398,6 @@
     }
 
     [self.channel invokeMethod:@"OneSignal#handleClickedInAppMessage" arguments:action.toJson];
-}
-
-#pragma mark In App Message lifecycle Handler
-- (void)onWillDisplayInAppMessageHandlerParams {
-    self.hasSetOnWillDisplayInAppMessageHandler = YES;
-
-    if (self.inAppMessage) {
-        [self onWillDisplayInAppMessage:self.inAppMessage];
-        self.inAppMessage = nil;
-    }
-}
-
-- (void)onDidDisplayInAppMessageHandlerParams {
-    self.hasSetOnDidDisplayInAppMessageHandler = YES;
-
-    if (self.inAppMessage) {
-        [self onDidDisplayInAppMessage:self.inAppMessage];
-        self.inAppMessage = nil;
-    }
-}
-
-- (void)onWillDismissInAppMessageHandlerParams {
-    self.hasSetOnWillDismissInAppMessageHandler = YES;
-
-    if (self.inAppMessage) {
-        [self onWillDismissInAppMessage:self.inAppMessage];
-        self.inAppMessage = nil;
-    }
-}
-
-- (void)onDidDismissInAppMessageHandlerParams {
-    self.hasSetOnDidDismissInAppMessageHandler = YES;
-
-    if (self.inAppMessage) {
-        [self onDidDismissInAppMessage:self.inAppMessage];
-        self.inAppMessage = nil;
-    }
 }
 
 #pragma mark OSInAppMessageLifeCycleHandler

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '3.9.1'
+  s.dependency 'OneSignalXCFramework', '3.10.0'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -25,6 +25,10 @@ typedef void EmailSubscriptionChangeHandler(OSEmailSubscriptionStateChanges chan
 typedef void SMSSubscriptionChangeHandler(OSSMSSubscriptionStateChanges changes);
 typedef void PermissionChangeHandler(OSPermissionStateChanges changes);
 typedef void InAppMessageClickedHandler(OSInAppMessageAction action);
+typedef void OnWillDisplayInAppMessageHandler(OSInAppMessage message);
+typedef void OnDidDisplayInAppMessageHandler(OSInAppMessage message);
+typedef void OnWillDismissInAppMessageHandler(OSInAppMessage message);
+typedef void OnDidDismissInAppMessageHandler(OSInAppMessage message);
 typedef void NotificationWillShowInForegroundHandler(OSNotificationReceivedEvent event);
 
 class OneSignal {
@@ -47,6 +51,10 @@ class OneSignal {
   SMSSubscriptionChangeHandler? _onSMSSubscriptionChangedHandler;
   PermissionChangeHandler? _onPermissionChangedHandler;
   InAppMessageClickedHandler? _onInAppMessageClickedHandler;
+  OnWillDisplayInAppMessageHandler? _onWillDisplayInAppMessageHandler;
+  OnDidDisplayInAppMessageHandler? _onDidDisplayInAppMessageHandler;
+  OnWillDismissInAppMessageHandler? _onWillDismissInAppMessageHandler;
+  OnDidDismissInAppMessageHandler? _onDidDismissInAppMessageHandler;
   NotificationWillShowInForegroundHandler? _onNotificationWillShowInForegroundHandler;
 
   // constructor method
@@ -112,6 +120,34 @@ class OneSignal {
   void setInAppMessageClickedHandler(InAppMessageClickedHandler handler) {
     _onInAppMessageClickedHandler = handler;
     _channel.invokeMethod("OneSignal#initInAppMessageClickedHandlerParams");
+  }
+
+  /// The in app message will display handler is called whenever the in app message
+  /// is about to be displayed
+  void setOnWillDisplayInAppMessageHandler(OnWillDisplayInAppMessageHandler handler) {
+    _onWillDisplayInAppMessageHandler = handler;
+    _channel.invokeMethod("OneSignal#onWillDisplayInAppMessageHandlerParams");
+  }
+
+  /// The in app message did display handler is called whenever the in app message
+  /// is displayed
+  void setOnDidDisplayInAppMessageHandler(OnDidDisplayInAppMessageHandler handler) {
+    _onDidDisplayInAppMessageHandler = handler;
+    _channel.invokeMethod("OneSignal#onDidDisplayInAppMessageHandlerParams");
+  }
+
+  /// The in app message will dismiss handler is called whenever the in app message
+  /// is about to be dismissed
+  void setOnWillDismissInAppMessageHandler(OnWillDismissInAppMessageHandler handler) {
+    _onWillDismissInAppMessageHandler = handler;
+    _channel.invokeMethod("OneSignal#onWillDismissInAppMessageHandlerParams");
+  }
+
+  /// The in app message did dismiss handler is called whenever the in app message
+  /// is dismissed
+  void setOnDidDismissInAppMessageHandler(OnDidDismissInAppMessageHandler handler) {
+    _onDidDismissInAppMessageHandler = handler;
+    _channel.invokeMethod("OneSignal#onDidDismissInAppMessageHandlerParams");
   }
 
   /// The notification foreground handler is called whenever a notification arrives
@@ -428,6 +464,22 @@ class OneSignal {
         this._onInAppMessageClickedHandler != null) {
       this._onInAppMessageClickedHandler!(
           OSInAppMessageAction(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onWillDisplayInAppMessage' &&
+        this._onWillDisplayInAppMessageHandler != null) {
+      this._onWillDisplayInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onDidDisplayInAppMessage' &&
+        this._onDidDisplayInAppMessageHandler != null) {
+      this._onDidDisplayInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onWillDismissInAppMessage' &&
+        this._onWillDismissInAppMessageHandler != null) {
+      this._onWillDismissInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onDidDismissInAppMessage' &&
+        this._onDidDismissInAppMessageHandler != null) {
+      this._onDidDismissInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
     } else if (call.method == 'OneSignal#handleNotificationWillShowInForeground' &&
         this._onNotificationWillShowInForegroundHandler != null) {
       this._onNotificationWillShowInForegroundHandler!(

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -124,30 +124,30 @@ class OneSignal {
 
   /// The in app message will display handler is called whenever the in app message
   /// is about to be displayed
-  void setOnWillDisplayInAppMessageHandler(OnWillDisplayInAppMessageHandler handler) {
+  void setOnWillDisplayInAppMessageHandler(
+      OnWillDisplayInAppMessageHandler handler) {
     _onWillDisplayInAppMessageHandler = handler;
-    _channel.invokeMethod("OneSignal#onWillDisplayInAppMessageHandlerParams");
   }
 
   /// The in app message did display handler is called whenever the in app message
   /// is displayed
-  void setOnDidDisplayInAppMessageHandler(OnDidDisplayInAppMessageHandler handler) {
+  void setOnDidDisplayInAppMessageHandler(
+      OnDidDisplayInAppMessageHandler handler) {
     _onDidDisplayInAppMessageHandler = handler;
-    _channel.invokeMethod("OneSignal#onDidDisplayInAppMessageHandlerParams");
   }
 
   /// The in app message will dismiss handler is called whenever the in app message
   /// is about to be dismissed
-  void setOnWillDismissInAppMessageHandler(OnWillDismissInAppMessageHandler handler) {
+  void setOnWillDismissInAppMessageHandler(
+      OnWillDismissInAppMessageHandler handler) {
     _onWillDismissInAppMessageHandler = handler;
-    _channel.invokeMethod("OneSignal#onWillDismissInAppMessageHandlerParams");
   }
 
   /// The in app message did dismiss handler is called whenever the in app message
   /// is dismissed
-  void setOnDidDismissInAppMessageHandler(OnDidDismissInAppMessageHandler handler) {
+  void setOnDidDismissInAppMessageHandler(
+      OnDidDismissInAppMessageHandler handler) {
     _onDidDismissInAppMessageHandler = handler;
-    _channel.invokeMethod("OneSignal#onDidDismissInAppMessageHandlerParams");
   }
 
   /// The notification foreground handler is called whenever a notification arrives

--- a/lib/src/in_app_message.dart
+++ b/lib/src/in_app_message.dart
@@ -34,3 +34,17 @@ class OSInAppMessageAction extends JSONStringRepresentable {
   }
 
 }
+
+class OSInAppMessage extends JSONStringRepresentable {
+  String? messageId;
+
+  OSInAppMessage(Map<String, dynamic> json) {
+    this.messageId = json["message_id"];
+  } 
+
+  String jsonRepresentation() {
+    return convertToJsonString({
+      'message_id': this.messageId
+    });
+  }
+}


### PR DESCRIPTION
## Description
## Line Summary
Adds the In-App Message Lifecycle Handler which includes up to 4 callbacks for the displaying and dismissing of In-App Messages.

## Details
### Motivation
This handler was added to give customers visibility into the display lifecycle of IAMs: when an IAM will be displayed, and also when it has been dismissed.

### Scope
Extra fields will show up if a user logs the OSInAppMessage instead of just its messageId property, which is fine.
In-App Messages are only read and not modified.

### Public API Changes
The documentation will need to be updated for react native to provide these new methods.
* Add `onWillDisplayInAppMessage`, `onDidDisplayInAppMessage`, `onWillDismissInAppMessage`, `onDidDismissInAppMessage` handlers to Android and iOS
* Add respective handlers to OneSignal dart file
* Add example handlers to the example app

## Testing
### Manual Testing
* Test device using IAM lifecycle handlers on Android and iOS. The IAM lifecycle handlers trigger on receiving an In-app message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/531)
<!-- Reviewable:end -->
