### PR TITLE
Use `ActivityAware` to get the Activity context

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -3,6 +3,9 @@ package com.onesignal.flutter;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+
 import com.onesignal.OSDeviceState;
 import com.onesignal.OSEmailSubscriptionObserver;
 import com.onesignal.OSEmailSubscriptionStateChanges;
@@ -42,6 +45,7 @@ public class OneSignalPlugin
         extends FlutterRegistrarResponder
         implements FlutterPlugin, 
         MethodCallHandler,
+        ActivityAware,
         OneSignal.OSNotificationOpenedHandler,
         OneSignal.OSInAppMessageClickHandler,
         OSSubscriptionObserver,
@@ -96,12 +100,29 @@ public class OneSignalPlugin
     OneSignal.setInAppMessageClickHandler(null);
   }
 
+  @Override
+  public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    this.context = binding.getActivity();
+  }
+
+  @Override
+  public void onDetachedFromActivity() {
+  }
+
+  @Override
+  public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+  }
+
+  @Override
+  public void onDetachedFromActivityForConfigChanges() {
+  }
+
   // This static method is only to remain compatible with apps that don’t use the v2 Android embedding.
   @Deprecated()
   @SuppressLint("Registrar")
   public static void registerWith(Registrar registrar) {
     final OneSignalPlugin plugin = new OneSignalPlugin();
-    plugin.init(registrar.context(), registrar.messenger());
+    plugin.init(registrar.activeContext(), registrar.messenger());
 
     // Create a callback for the flutterRegistrar to connect the applications onDestroy
     registrar.addViewDestroyListener(new PluginRegistry.ViewDestroyListener() {


### PR DESCRIPTION
# Description
## One Line Summary
Implement the Flutter `ActivityAware` interface to pass the `Activity` context instead of `Application` context to `setAppId`.

## Details

### Motivation
Fixes https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/509. What we were experiencing was that on the first run of the app, the current activity would be `null` so that IAMs don't display and the app is sensed as in the background even when in the foreground. Backgrounding the app and returning resumed normal behavior.

Why? After the [changes to support Android V2 embedding](https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/486), the plugin is set up in `onAttachedToEngine` and the Application Context is **not** an instance of Activity.

When this context is eventually passed to `setAppId`, we end up with the current activity is `null` which leads to some problems. Note that this is only a problem on the first run of the app.

This PR implements the `ActivityAware` interface and in `onAttachedToActivity`, updates the existing context to the activity received, following some [Flutter documentation here](https://docs.flutter.dev/development/packages-and-plugins/plugin-api-migration).

In addition, use `activeContext()` instead of `context()` for the registrar for Flutter's v1 embedding to get the application context. Doing some testing shows the former provides the `MainActivity` while the latter provides `FlutterApplication`.

### Scope
During testing, `onAttachedToActivity` is called right after `onAttachedToEngine` so we expect to get the activity context immediately. 

There are 3 other `ActivityAware` methods are not implemented as they don't appear to be needed. We only need the first call to Flutter's `onAttachedToActivity` during the first run of the app. After that, the OneSignal `ActivityLifecycleHandler` should be triggered and set the activities.

# Testing
## Unit testing
N/A

## Manual testing
Tested on Pixel 5 emulator on API 30 and checking logs for `onAttachedToEngine` and `onAttachedToActivity` and what context is passed to `setAppId`. Also put logging for the other 3 methods in `ActivityAware` and they are never logged.
- [x] Fresh install of the app
- [x] Backgrounding the app and returning
- [x] Kill the app and reopen
- [ ] ❗ Not tested: navigating between multiple activities within the app, the example app is only 1 screen.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/534)
<!-- Reviewable:end -->
