### PR TITLE
Add iOS only `setLaunchURLsInApp` function

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,6 +103,9 @@ class _MyAppState extends State<MyApp> {
     await OneSignal.shared
         .setAppId("380dc082-5231-4cc2-ab51-a03da5a0e4c2");
 
+    // iOS-only method to open launch URLs in Safari when set to false
+    OneSignal.shared.setLaunchURLsInApp(false);
+
     bool requiresConsent = await OneSignal.shared.requiresUserPrivacyConsent();
 
     this.setState(() {

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -125,6 +125,8 @@
         [self disablePush:call withResult:result];
     else if ([@"OneSignal#postNotification" isEqualToString:call.method])
         [self postNotification:call withResult:result];
+    else if ([@"OneSignal#setLaunchURLsInApp" isEqualToString:call.method])
+        [self setLaunchURLsInApp:call withResult:result];
     else if ([@"OneSignal#promptLocation" isEqualToString:call.method])
         [self promptLocation:call withResult:result];
     else if ([@"OneSignal#setLocationShared" isEqualToString:call.method])
@@ -242,6 +244,12 @@
     } onFailure:^(NSError *error) {
         result(error.flutterError);
     }];
+}
+
+- (void)setLaunchURLsInApp:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL isEnabled = [call.arguments[@"isEnabled"] boolValue];
+    [OneSignal setLaunchURLsInApp:isEnabled];
+    result(nil);
 }
 
 - (void)promptLocation:(FlutterMethodCall *)call withResult:(FlutterResult)result {

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:onesignal_flutter/src/permission.dart';
 import 'package:onesignal_flutter/src/subscription.dart';
@@ -162,6 +163,19 @@ class OneSignal {
   void completeNotification(String notificationId, bool shouldDisplay) {
     _channel.invokeMethod("OneSignal#completeNotification",
         {'notificationId': notificationId, 'shouldDisplay': shouldDisplay});
+  }
+
+  /// Only applies to iOS
+  /// Sets if launch URLs should be opened within the application or in Safari.
+  /// When set to true, launch URLs will open an in-app browser.
+  Future<void> setLaunchURLsInApp(bool isEnabled) async {
+    if (Platform.isIOS) {
+      await _channel.invokeMethod(
+        "OneSignal#setLaunchURLsInApp", {'isEnabled': isEnabled});
+    } else {
+      _onesignalLog(OSLogLevel.info,
+          "setLaunchURLsInApp: this function is not supported on Android");
+    }
   }
 
   /// Allows you to completely disable the SDK until your app calls the


### PR DESCRIPTION
# Description
## One Line Summary
Adds the `setLaunchURLsInApp` function that is for iOS only.

## Details
The function, previously only available via the native iOS SDK, does the following:
> This method can be used to set if launch URLs should be opened in Safari or within the application. The default value is `true` which opens an in-app browser. Setting this to `false` will open in Safari.

For Android, just log that it is unsupported and don't add to plugin.
* Add `setLaunchURLsInApp` method to OneSignal iOS plugin
* Add `setLaunchURLsInApp` bridge method to onesignal_flutter.dart
* Add `setLaunchURLsInApp` method to the example app with `false`

## Test
* **iOS**: Tested on iPhone 13 using the example app calling `setLaunchURLsInApp` with `true` and `false`. Tested with OneSignal-iOS-SDK 3.10.1 that remedied the problem with calling after init.
* **Android**: Tested on emulator that no error occurred and logged the statement "setLaunchURLsInApp: this function is not supported on Android".
* Did not add unit testing as this method was not added to the Android plugin and the mock channel was not being called as a result, leading to failing unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/542)
<!-- Reviewable:end -->
