### PR TITLE
[Feature] Add callbacks to `setLanguage`

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ class _MyAppState extends State<MyApp> {
   String? _emailAddress;
   String? _smsNumber;
   String? _externalUserId;
+  String? _language;
   bool _enableConsentButton = false;
 
   // CHANGE THIS parameter to true if you want to test GDPR privacy consent
@@ -181,6 +182,18 @@ class _MyAppState extends State<MyApp> {
       print("Successfully set email");
     }).catchError((error) {
       print("Failed to set email with error: $error");
+    });
+  }
+
+  void _handleSetLanguage() {
+    if (_language == null) return;
+
+    print("Setting language");
+
+    OneSignal.shared.setLanguage(_language!).then((response) {
+      print("Successfully set language with response: $response");
+    }).catchError((error) {
+      print("Failed to set language with error: $error");
     });
   }
 
@@ -509,6 +522,30 @@ class _MyAppState extends State<MyApp> {
                   new TableRow(children: [
                     new OneSignalButton(
                         "Remove External User ID", _handleRemoveExternalUserId, !_enableConsentButton)
+                  ]),
+                  new TableRow(children: [
+                    new TextField(
+                      textAlign: TextAlign.center,
+                      decoration: InputDecoration(
+                          hintText: "Language",
+                          labelStyle: TextStyle(
+                            color: Color.fromARGB(255, 212, 86, 83),
+                          )),
+                      onChanged: (text) {
+                        this.setState(() {
+                          _language = text == "" ? null : text;
+                        });
+                      },
+                    )
+                  ]),
+                  new TableRow(children: [
+                    Container(
+                      height: 8.0,
+                    )
+                  ]),
+                  new TableRow(children: [
+                    new OneSignalButton(
+                        "Set Language", _handleSetLanguage, !_enableConsentButton)
                   ]),
                   new TableRow(children: [
                     new Container(

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -338,7 +338,12 @@
         language = nil;
     }
 
-    [OneSignal setLanguage:language];
+    [OneSignal setLanguage:language withSuccess:^(NSDictionary *results) {
+        result(results);
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Set language Failure with error: %@", error]];
+        result(error.flutterError);
+    }];
 }
 
 - (void)initNotificationOpenedHandlerParams {

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -379,6 +379,8 @@ class OneSignal {
     return results.cast<String, dynamic>();
   }
 
+  /// Sets the user's language.
+  /// Applies also to the email and/or SMS player if those are logged in on the device.
   Future<Map<String, dynamic>> setLanguage(String language) async {
     Map<dynamic, dynamic> results =
         await (_channel.invokeMethod("OneSignal#setLanguage", {'language' : language}));


### PR DESCRIPTION
# Description
## One Line Summary
Adds callbacks for setting language (`setLanguage` method).

## Details

### Motivation
Provides developers with success and failure callbacks.

### Scope
* Add `setLanguage` success and failure callbacks to Android and iOS methods.
* On **Android**, if multiple channels are set (ie push, email, SMS), the developer's callback will fire once for the first successful or failed channel and subsequent success or failure callbacks will not be invoked.
* On **iOS**, if multiple channels are set (ie push, email, SMS), the callback will be invoked once with the states of all the channels.
* When testing **Android**, the `onSuccess` response from the native SDK is always `null`. When this is `null`, I pass through a custom object, because passing through the `null` object crashes in Flutter.
    ```java
    {'success' : 'true', 'message' : 'Successfully set language.'}
    ```
* Android always passes through a `null` response, because [this line](https://github.com/OneSignal/OneSignal-Android-SDK/blob/da8c8d891d616ade3b5b152318d9f0f2c57371b6/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java#L633) always has a `null` language.

### How to Use
```dart
    OneSignal.shared.setLanguage("fr").then((response) { // Example of setting the language to French.
        print("Successfully set language with response: $response");
    }).catchError((error) {
        print("Failed to set language with error: $error");
    });
```

# Testing

## Manual testing
Tested setting various languages on iOS and Android.
* ✅ Tested setting a language without using any callbacks.
* ✅ Tested setting a language that accepts the response and catches the failure.
* ✅ Tested setting email and SMS first, then setting a language. See below for the responses the developer receives.

```dart
// Android success
{success: true, message: Successfully set language.}

// iOS success
{email: {success: true}, push: {success: true}}

// Android failure example: turn off wifi and data
PlatformException(OneSignal, Encountered an error when setLanguage: Failed to set language., null, null)

// iOS failure example: turn off wifi and data
// Unfortunately, the flutterError does not give much detail.
PlatformException(0, The operation couldn’t be completed. (com.onesignal.language error 0.), null, null)
```
 
# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/568)
<!-- Reviewable:end -->
