### PR TITLE
Remove the OneSignal gradle plugin from the example app.

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,17 +1,3 @@
-buildscript {
-    repositories {
-        // ...
-        maven { url 'https://plugins.gradle.org/m2/' } // Gradle Plugin Portal
-    }
-    dependencies {
-        // ...
-        // OneSignal-Gradle-Plugin
-        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.10.2, 0.99.99]'
-    }
-}
-
-apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
-
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {


### PR DESCRIPTION
# Description
## One Line Summary
Remove the inclusion of the OneSignal gradle plugin from the example app.

### Motivation
The OneSignal gradle plugin for Android is designed to (1) ensure the `compileSdkVersion` is 31 or higher and (2) ensure (mostly) firebase dependent libraries in use by the app & onesignal are compatible.  The dependent library compatibility problem has been less of an issue, making the plugin less useful.  However inclusion of the plugin itself has caused side-effect issues (example:  https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/573).

As a result, including the OneSignal Gradle plugin is no longer considered standard when configuring an app to use the OneSignal Flutter SDK.  The plugin can still be used if there are dependent library versioning issues.


### Scope
When building the app for Android, the OneSignal gradle plugin is no longer included in the build scripts, and is therefore no longer part of the build process.

# Testing

## Manual testing
Built the example application and ensure proper functioning.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.