### PR TITLE
Add Live Activities support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -580,12 +580,14 @@ class OneSignalButtonState extends State<OneSignalButton> {
     return new Table(
       children: [
         new TableRow(children: [
-          new FlatButton(
-            disabledColor: Color.fromARGB(180, 212, 86, 83),
-            disabledTextColor: Colors.white,
-            color: Color.fromARGB(255, 212, 86, 83),
-            textColor: Colors.white,
-            padding: EdgeInsets.all(8.0),
+          new TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor:Colors.white,
+              disabledForegroundColor: Colors.white,
+              backgroundColor: Color.fromARGB(255, 212, 86, 83),
+              disabledBackgroundColor:Color.fromARGB(180, 212, 86, 83),
+              padding: EdgeInsets.all(8.0),
+            ),
             child: new Text(widget.title),
             onPressed: widget.enabled ? widget.onPressed : null,
           )

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -153,6 +153,10 @@
         [self initNotificationWillShowInForegroundHandlerParams];
     else if ([@"OneSignal#completeNotification" isEqualToString:call.method])
         [self completeNotification:call withResult:result];
+    else if ([@"OneSignal#enterLiveActivity" isEqualToString:call.method])
+        [self enterLiveActivity:call withResult:result];
+    else if ([@"OneSignal#exitLiveActivity" isEqualToString:call.method])
+        [self exitLiveActivity:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -403,6 +407,30 @@
     [self.receivedNotificationCache removeObjectForKey:notificationId];
 }
 
+#pragma mark Live Activity
+
+- (void)enterLiveActivity:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *activityId = call.arguments[@"activityId"];
+    NSString *token = call.arguments[@"token"];
+
+    [OneSignal enterLiveActivity:activityId withToken:token withSuccess:^(NSDictionary *results) {
+        result(results);
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"enterLiveActivity Failure with error: %@", error]];
+        result(error.flutterError);
+    }];
+}
+
+- (void)exitLiveActivity:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *activityId = call.arguments[@"activityId"];
+
+    [OneSignal exitLiveActivity:activityId withSuccess:^(NSDictionary *results) {
+        result(results);
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"exitLiveActivity Failure with error: %@", error]];
+        result(error.flutterError);
+    }];
+}
 
 #pragma mark In App Message Click Handler
 - (void)handleInAppMessageClicked:(OSInAppMessageAction *)action {

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '3.11.4'
+  s.dependency 'OneSignalXCFramework', '3.12.3'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -312,6 +312,29 @@ class OneSignal {
     return await _channel.invokeMethod("OneSignal#clearOneSignalNotifications");
   }
 
+  /// Only applies to iOS
+  /// Associates a temporary push token with an Activity ID on the OneSignal server.
+  Future<void> enterLiveActivity(String activityId, String token) async {
+    if (Platform.isIOS) {
+      await _channel.invokeMethod("OneSignal#enterLiveActivity", {'activityId': activityId, 'token': token});
+    } else {
+      _onesignalLog(OSLogLevel.info,
+          "enterLiveActivity: this function is not supported on Android");
+    }
+  }
+
+  /// Only applies to iOS
+  /// Deletes activityId associated temporary push token on the OneSignal server.
+  Future<void> exitLiveActivity(String activityId) async {
+    if (Platform.isIOS) {
+      await _channel.invokeMethod("OneSignal#exitLiveActivity",
+        {'activityId': activityId});
+    } else {
+      _onesignalLog(OSLogLevel.info,
+          "exitLiveActivity: this function is not supported on Android");
+    }
+  }
+
   /// Allows you to manually cancel a single OneSignal notification based on its Android notification integer ID
   void removeNotification(int notificationId) {
     _channel.invokeMethod("OneSignal#removeNotification",


### PR DESCRIPTION
# Description
## One Line Summary
Adds Live Activity support.

## Details

### Motivation
Adding 2 SDK methods that allow a customer to register their temporary live activity token with an activity ID on OneSignal's backend:

1. enterLiveActivity
2. exitLiveActivity

### Scope
Adding bridging to access the two iOS SDK methods.

# Testing
## Unit testing
The iOS repo contains tests, this is only bridging

## Manual testing
Testing limited since no real push token is available.
- Tested that the Flutter example app can call these two methods and receive the onFailure response with a correct 404 error.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-flutter-sdk/621)
<!-- Reviewable:end -->
