### PR TITLE
Adding Debug namespace

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -179,7 +179,6 @@
 				6BBCCF44B691DF76AC7D7376 /* Pods-Runner.debug.xcconfig */,
 				47FF2D2152AD7B79C3388A8D /* Pods-Runner.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -596,10 +595,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -625,10 +621,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -657,12 +650,8 @@
 				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -690,12 +679,8 @@
 				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,10 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -39,14 +36,13 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -63,8 +59,6 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class _MyAppState extends State<MyApp> {
 
     OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
 
-    OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
+    OneSignal.Debug.setVisualLevel(OSLogLevel.verbose);
 
     // NOTE: Replace with your own app ID from https://www.onesignal.com
     OneSignal.shared.initialize("9c59a2aa-315a-4bf9-9fef-f76d575d3202");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,12 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     if (!mounted) return;
 
-    // OneSignal.shared.setLogLevel(OSLogLevel.verbose, OSLogLevel.none);
+    OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
+
+    OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
+
+    // NOTE: Replace with your own app ID from https://www.onesignal.com
+    OneSignal.shared.initialize("9c59a2aa-315a-4bf9-9fef-f76d575d3202");
 
     // OneSignal.shared.setRequiresUserPrivacyConsent(_requireConsent);
 
@@ -99,10 +104,6 @@ class _MyAppState extends State<MyApp> {
     // OneSignal.shared.setOnDidDismissInAppMessageHandler((message) {
     //   print("ON DID DISMISS IN APP MESSAGE ${message.messageId}");
     // });
-
-    // NOTE: Replace with your own app ID from https://www.onesignal.com
-    await OneSignal.shared
-        .setAppId("380dc082-5231-4cc2-ab51-a03da5a0e4c2");
 
     // iOS-only method to open launch URLs in Safari when set to false
     // OneSignal.shared.setLaunchURLsInApp(false);

--- a/ios/Classes/OSFlutterDebug.h
+++ b/ios/Classes/OSFlutterDebug.h
@@ -25,12 +25,12 @@
  * THE SOFTWARE.
  */
 
+
+#import <Foundation/Foundation.h>
 #import <Flutter/Flutter.h>
-#import <OneSignalFramework/OneSignalFramework.h>
 
-@interface OneSignalPlugin : NSObject<FlutterPlugin>
+@interface OSFlutterDebug : NSObject<FlutterPlugin>
 
-// Do NOT initialize instances of this class.
-// You must only reference the shared instance.
-+ (instancetype)sharedInstance;
+@property (strong, nonatomic) FlutterMethodChannel *channel;
+
 @end

--- a/ios/Classes/OSFlutterDebug.m
+++ b/ios/Classes/OSFlutterDebug.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2023 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,12 +25,36 @@
  * THE SOFTWARE.
  */
 
-#import <Flutter/Flutter.h>
+#import "OSFlutterDebug.h"
 #import <OneSignalFramework/OneSignalFramework.h>
+#import "OSFlutterCategories.h"
 
-@interface OneSignalPlugin : NSObject<FlutterPlugin>
+@implementation OSFlutterDebug
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    OSFlutterDebug *instance = [OSFlutterDebug new];
 
-// Do NOT initialize instances of this class.
-// You must only reference the shared instance.
-+ (instancetype)sharedInstance;
+    instance.channel = [FlutterMethodChannel
+                        methodChannelWithName:@"OneSignal#debug"
+                        binaryMessenger:[registrar messenger]];
+
+    [registrar addMethodCallDelegate:instance channel:instance.channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+    if ([@"OneSignal#setLogLevel" isEqualToString:call.method])
+        [self setLogLevel:call];
+    else if ([@"OneSignal#setVisualLevel" isEqualToString:call.method])
+        [self setVisualLevel:call];
+    else 
+        result(FlutterMethodNotImplemented);
+}
+
+- (void)setLogLevel:(FlutterMethodCall *)call {
+    [OneSignal.Debug setLogLevel:call.arguments[@"logLevel"]];
+}
+
+- (void)setVisualLevel:(FlutterMethodCall *)call {
+    [OneSignal.Debug setVisualLevel:call.arguments[@"visualLevel"]];
+}
+
 @end

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -27,6 +27,8 @@
 
 #import "OneSignalPlugin.h"
 #import "OSFlutterCategories.h"
+#import "OSFlutterDebug.h"
+
 
 @interface OneSignalPlugin ()
 
@@ -58,29 +60,24 @@
 #pragma mark FlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
-    [OneSignal initialize:nil withLaunchOptions:nil];
     [OneSignal setMSDKType:@"flutter"];
-
-    // Wrapper SDK's call init with no app ID early on in the
-    // app lifecycle. The developer will call init() later on
-    // from the Flutter plugin channel.
 
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel
                                      methodChannelWithName:@"OneSignal"
                                      binaryMessenger:[registrar messenger]];
 
     [registrar addMethodCallDelegate:OneSignalPlugin.sharedInstance channel:OneSignalPlugin.sharedInstance.channel];
-
+    [OSFlutterDebug registerWithRegistrar:registrar];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"OneSignal#initialize" isEqualToString:call.method])
-        [self initialize:call withResult:result];
+        [self initialize:call];
     else 
         result(FlutterMethodNotImplemented);
 }
 
-- (void)initialize:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+- (void)initialize:(FlutterMethodCall *)call {
 
     [OneSignal initialize:call.arguments[@"appId"] withLaunchOptions:nil];
     // If the user has required privacy consent, the SDK will not
@@ -91,8 +88,7 @@
     // } else {
     //     [self addObservers];
     // }
-    result(nil);
+   // result(nil);
 }
-
 
 @end

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -4,9 +4,11 @@ import 'package:flutter/services.dart';
 import 'package:onesignal_flutter/src/permission.dart';
 import 'package:onesignal_flutter/src/defines.dart';
 import 'package:onesignal_flutter/src/utils.dart';
+import 'package:onesignal_flutter/src/onesignaldebug.dart';
 
 export 'src/permission.dart';
 export 'src/defines.dart';
+export 'src/onesignaldebug.dart';
 
 
 // Handlers for various events
@@ -19,30 +21,24 @@ class OneSignal {
   /// so if you create multiple instances of OneSignal, they will
   /// mostly share the same state.
   static OneSignal shared = new OneSignal();
+  static OneSignalDebug Debug = new OneSignalDebug();
   
 
   // private channels used to bridge to ObjC/Java
   MethodChannel _channel = const MethodChannel('OneSignal');
-  // MethodChannel _tagsChannel = const MethodChannel('OneSignal#tags');
-
-  // event handlers
-  PermissionChangeHandler? _onPermissionChangedHandler;
-
+ 
+  /// The initializer for OneSignal. 
+  ///
+  /// The initializer accepts an [appId] which the developer can get 
+  /// from the OneSignal consoleas well as a dictonary of [launchOptions]
+  void initialize(String appId) {
+    _channel.invokeMethod(
+        'OneSignal#initialize', {'appId': appId});
+  }
   // constructor method
   OneSignal() {
     this._channel.setMethodCallHandler(_handleMethod);
   }
-
-  /// The initializer for OneSignal. Note that this initializer
-  /// accepts an iOSSettings object, in Android you can pass null.
-  Future<void> setAppId(String appId) async {
-    // _onesignalLog(OSLogLevel.verbose,
-    //     "Initializing the OneSignal Flutter SDK ($sdkVersion)");
-
-    await _channel.invokeMethod(
-        'OneSignal#initialize', {'appId': appId});
-  }
-
    // Private function that gets called by ObjC/Java
   Future<Null> _handleMethod(MethodCall call) async {
     return null;

--- a/lib/src/onesignaldebug.dart
+++ b/lib/src/onesignaldebug.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'package:flutter/services.dart';
+import 'package:onesignal_flutter/src/defines.dart';
+
+class OneSignalDebug {
+
+  // private channels used to bridge to ObjC/Java
+  MethodChannel _channel = const MethodChannel('OneSignal#debug');
+
+  // constructor method
+  OneSignalDebug() {
+    this._channel.setMethodCallHandler(_handleMethod);
+  }
+   // Private function that gets called by ObjC/Java
+  Future<Null> _handleMethod(MethodCall call) async {
+    return null;
+  }
+
+  /// Sets the log level for the SDK. 
+  ///
+  /// The parameter [logLevel] controls
+  /// how verbose logs in the console/logcat are
+  void setLogLevel(OSLogLevel logLevel) {
+    _channel.invokeMethod("OneSignal#setLogLevel",
+        {'console': logLevel.index});
+  }
+
+  /// Sets the log level for the SDK. 
+  ///
+  /// The parameter [visualLevel] controls
+  /// if the SDK will show alerts for each logged message
+  void setVisualLevel( OSLogLevel visualLevel) {
+    _channel.invokeMethod("OneSignal#setVisualLevel",
+        {'visual': visualLevel.index});
+  }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Create Debug namespace to handle changing visual and text log levels.

## Details

### Motivation
User Model requires namespacing to organize functions

### Scope
Logging methods have been moved to their own namespace and will be invoked as:
`OneSignal.Debug.setLogLevel(OSLogLevel.verbose)`
`OneSignal.Debug.setVisualLevel(OSLogLevel.verbose)`

### OPTIONAL - Other
This PR adds a debug namespace and the relevant iOS bridge, android to follow.

# Testing
## Unit testing
No unit testing was used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/640)
<!-- Reviewable:end -->
