### PR TITLE
Adding methods to the OneSignal static object

### DIFF
--- a/ios/Classes/OSFlutterDebug.m
+++ b/ios/Classes/OSFlutterDebug.m
@@ -50,11 +50,13 @@
 }
 
 - (void)setLogLevel:(FlutterMethodCall *)call {
-    [OneSignal.Debug setLogLevel:call.arguments[@"logLevel"]];
+    ONE_S_LOG_LEVEL logLevel = (ONE_S_LOG_LEVEL)[call.arguments[@"logLevel"] intValue];
+    [OneSignal.Debug setLogLevel:logLevel];
 }
 
 - (void)setVisualLevel:(FlutterMethodCall *)call {
-    [OneSignal.Debug setVisualLevel:call.arguments[@"visualLevel"]];
+    ONE_S_LOG_LEVEL visualLogLevel = (ONE_S_LOG_LEVEL)[call.arguments[@"visualLevel"] intValue];
+    [OneSignal.Debug setVisualLevel:visualLogLevel];
 }
 
 @end

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -75,9 +75,27 @@
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"OneSignal#initialize" isEqualToString:call.method])
         [self initialize:call];
-    else 
+    else if ([@"OneSignal#login" isEqualToString:call.method])
+        result(@(OneSignal.login));
+    else if ([@"OneSignal#getPrivacyConsent" isEqualToString:call.method])
+        result(@(OneSignal.getPrivacyConsent));
+    else if ([@"OneSignal#setPrivacyConsent" isEqualToString:call.method])
+        [self getPrivacyConsent:call];
+    else if ([@"OneSignal#requiresPrivacyConsent" isEqualToString:call.method])
+        result(@(OneSignal.requiresPrivacyConsent));
+    else if ([@"OneSignal#setRequiresPrivacyConsent" isEqualToString:call.method])
+        [self setRequiresPrivacyConsent:call];
+    else if ([@"OneSignal#setLaunchURLsInApp" isEqualToString:call.method])
+        [self setLaunchURLsInApp:call];
+     else if ([@"OneSignal#enterLiveActivity" isEqualToString:call.method])
+        [self enterLiveActivity:call withResult:result];
+    else if ([@"OneSignal#exitLiveActivity" isEqualToString:call.method])
+        [self exitLiveActivity:call withResult:result];
+    else
         result(FlutterMethodNotImplemented);
 }
+
+#pragma mark Init
 
 - (void)initialize:(FlutterMethodCall *)call {
 
@@ -91,6 +109,60 @@
     //     [self addObservers];
     // }
    // result(nil);
+}
+
+#pragma mark Login Logout
+
+- (void)login:(FlutterMethodCall *)call {
+    [OneSignal login:call.arguments[@"externalId"]];
+}
+
+- (void)logout:(FlutterMethodCall *)call {
+    [OneSignal logout];
+}
+
+#pragma mark Privacy Consent
+
+- (void)setPrivacyConsent:(FlutterMethodCall *)call {
+    BOOL granted = [call.arguments[@"granted"] boolValue];
+    [OneSignal setPrivacyConsent:granted];
+}
+
+- (void)setRequiresPrivacyConsent:(FlutterMethodCall *)call {
+    BOOL required = [call.arguments[@"required"] boolValue];
+    [OneSignal setRequiresPrivacyConsent:required];  
+}
+
+#pragma mark Launch Urls In App
+
+- (void)setLaunchURLsInApp:(FlutterMethodCall *)call {
+    BOOL launchUrlsInApp = [call.arguments[@"launchUrlsInApp"] boolValue];
+    [OneSignal setLaunchURLsInApp:launchUrlsInApp]
+}
+
+#pragma mark Live Activity
+
+- (void)enterLiveActivity:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *activityId = call.arguments[@"activityId"];
+    NSString *token = call.arguments[@"token"];
+
+    [OneSignal enterLiveActivity:activityId withToken:token withSuccess:^(NSDictionary *results) {
+        result(results);
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"enterLiveActivity Failure with error: %@", error]];
+        result(error.flutterError);
+    }];
+}
+
+- (void)exitLiveActivity:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *activityId = call.arguments[@"activityId"];
+
+    [OneSignal exitLiveActivity:activityId withSuccess:^(NSDictionary *results) {
+        result(results);
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"exitLiveActivity Failure with error: %@", error]];
+        result(error.flutterError);
+    }];
 }
 
 @end

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -36,12 +36,94 @@ class OneSignal {
     _channel.invokeMethod(
         'OneSignal#initialize', {'appId': appId});
   }
-  // constructor method
-  // OneSignal() {
-  //   this._channel.setMethodCallHandler(_handleMethod);
-  // }
-  //  // Private function that gets called by ObjC/Java
-  // Future<Null> _handleMethod(MethodCall call) async {
-  //   return null;
-  // }
+
+  /// Login to OneSignal under the user identified by the [externalId] provided. 
+  /// 
+  /// The act of logging a user into the OneSignal SDK will switch the 
+  /// [user] context to that specific user.
+  void login(String externalId) {
+    _channel.invokeMethod(
+        'OneSignal#login', {'externalId': externalId});
+  }
+
+  /// Logout the user previously logged in via [login]. The [user] property now 
+  ///
+  /// references a new device-scoped user. A device-scoped user has no user identity 
+  /// that can later be retrieved, except through this device as long as the app 
+  /// remains installed and the app data is not cleared.
+  void logout() {
+    _channel.invokeMethod(
+        'OneSignal#logout');
+  }
+
+  /// Indicates whether privacy consent has been granted. 
+  ///
+  /// This field is only relevant when the application has 
+  /// opted into data privacy protections. See [requiresPrivacyConsent].
+  Future<bool> getPrivacyConsent() async {
+    var val =
+        await _channel.invokeMethod("OneSignal#getPrivacyConsent");
+
+    return val as bool;
+  }
+
+  /// Sets the whether or not privacy consent has been [granted]
+  ///
+  /// This field is only relevant when the application has 
+  /// opted into data privacy protections. See [requiresPrivacyConsent].
+  Future<void> setPrivacyConsent(bool granted) async {
+    await _channel
+        .invokeMethod("OneSignal#setPrivacyConsent", {'granted': granted});
+  }
+
+  /// A boolean value indicating if the OneSignal SDK is waiting for the
+  /// user's consent before it can initialize (if you set the app to
+  /// require the user's consent)
+  Future<bool> requiresPrivacyConsent() async {
+    var val =
+        await _channel.invokeMethod("OneSignal#requiresPrivacyConsent");
+
+    return val as bool;
+  }
+
+  /// Allows you to completely disable the SDK until your app calls the
+  /// OneSignal.setPrivacyConsent(true) function. This is useful if you want
+  /// to show a Terms and Conditions or privacy popup for GDPR.
+  Future<void> setRequiresPrivacyConsent(bool require) async {
+    await _channel.invokeMethod(
+        "OneSignal#setRequiresPrivacyConsent", {'required': require});
+  }
+
+  /// This method can be used to set if launch URLs should be opened in safari or
+  /// within the application. Set to true to launch all notifications with a URL 
+  /// in the app instead of the default web browser. Make sure to call setLaunchURLsInApp 
+  /// before the initialize call.
+  void setLaunchURLsInApp(bool launchUrlsInApp) {
+    _channel.invokeMethod(
+        'OneSignal#setLaunchURLsInApp', {'launchUrlsInApp': launchUrlsInApp});
+  }
+
+  /// Only applies to iOS
+  /// Associates a temporary push token with an Activity ID on the OneSignal server.
+  Future<void> enterLiveActivity(String activityId, String token) async {
+    if (Platform.isIOS) {
+      await _channel.invokeMethod("OneSignal#enterLiveActivity", {'activityId': activityId, 'token': token});
+    } else {
+      _onesignalLog(OSLogLevel.info,
+          "enterLiveActivity: this function is not supported on Android");
+    }
+  }
+
+  /// Only applies to iOS
+  /// Deletes activityId associated temporary push token on the OneSignal server.
+  Future<void> exitLiveActivity(String activityId) async {
+    if (Platform.isIOS) {
+      await _channel.invokeMethod("OneSignal#exitLiveActivity",
+        {'activityId': activityId});
+    } else {
+      _onesignalLog(OSLogLevel.info,
+          "exitLiveActivity: this function is not supported on Android");
+    }
+  }
+
 }

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -14,7 +14,7 @@ class OneSignalDebug {
   /// how verbose logs in the console/logcat are
   void setLogLevel(OSLogLevel logLevel) {
     _channel.invokeMethod("OneSignal#setLogLevel",
-        {'console': logLevel.index});
+        {'logLevel': logLevel.index});
   }
 
   /// Sets the log level for the SDK. 
@@ -23,6 +23,6 @@ class OneSignalDebug {
   /// if the SDK will show alerts for each logged message
   void setVisualLevel( OSLogLevel visualLevel) {
     _channel.invokeMethod("OneSignal#setVisualLevel",
-        {'visual': visualLevel.index});
+        {'visualLevel': visualLevel.index});
   }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Update methods that are under the OneSignal Static Object

## Details

### Motivation
Some methods are to remain on the main OneSignal class, with some updates.

### Scope
Methods to remain on the OneSignal class will be invoked as:
`OneSignal.login("externalId");`
`OneSignal.logout();`
`OneSignal.setPrivacyConsent(true);`
`var consent = OneSignal.getPrivacyConsent();`
`OneSignal.setRequiresPrivacyConsent(true);`
`var requireConsent = OneSignal.getRequiresPrivacyConsent();`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/642)
<!-- Reviewable:end -->
