### PR TITLE
Notification and pushSubscription namespaces

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,7 +32,7 @@ target 'Runner' do
 end
 
 target 'OneSignalNotificationServiceExtension' do
-  pod 'OneSignalXCFramework', '5.0.0-alpha-02'
+  pod 'OneSignalXCFramework', '5.0.0-beta-01'
 end
 
 post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Flutter (1.0.0)
-  - onesignal_flutter (5.0.0-alpha-02):
+  - onesignal_flutter (5.0.0-beta-01):
     - Flutter
-    - OneSignalXCFramework (= 5.0.0-alpha-02)
-  - OneSignalXCFramework (5.0.0-alpha-02):
-    - OneSignalXCFramework/OneSignalCore (= 5.0.0-alpha-02)
-    - OneSignalXCFramework/OneSignalExtension (= 5.0.0-alpha-02)
-    - OneSignalXCFramework/OneSignalNotifications (= 5.0.0-alpha-02)
-    - OneSignalXCFramework/OneSignalOSCore (= 5.0.0-alpha-02)
-    - OneSignalXCFramework/OneSignalOutcomes (= 5.0.0-alpha-02)
-    - OneSignalXCFramework/OneSignalUser (= 5.0.0-alpha-02)
-  - OneSignalXCFramework/OneSignalCore (5.0.0-alpha-02)
-  - OneSignalXCFramework/OneSignalExtension (5.0.0-alpha-02):
+    - OneSignalXCFramework (= 5.0.0-beta-01)
+  - OneSignalXCFramework (5.0.0-beta-01):
+    - OneSignalXCFramework/OneSignalCore (= 5.0.0-beta-01)
+    - OneSignalXCFramework/OneSignalExtension (= 5.0.0-beta-01)
+    - OneSignalXCFramework/OneSignalNotifications (= 5.0.0-beta-01)
+    - OneSignalXCFramework/OneSignalOSCore (= 5.0.0-beta-01)
+    - OneSignalXCFramework/OneSignalOutcomes (= 5.0.0-beta-01)
+    - OneSignalXCFramework/OneSignalUser (= 5.0.0-beta-01)
+  - OneSignalXCFramework/OneSignalCore (5.0.0-beta-01)
+  - OneSignalXCFramework/OneSignalExtension (5.0.0-beta-01):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalNotifications (5.0.0-alpha-02):
+  - OneSignalXCFramework/OneSignalNotifications (5.0.0-beta-01):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.0.0-alpha-02):
+  - OneSignalXCFramework/OneSignalOSCore (5.0.0-beta-01):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.0.0-alpha-02):
+  - OneSignalXCFramework/OneSignalOutcomes (5.0.0-beta-01):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.0.0-alpha-02):
+  - OneSignalXCFramework/OneSignalUser (5.0.0-beta-01):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -31,7 +31,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - onesignal_flutter (from `.symlinks/plugins/onesignal_flutter/ios`)
-  - OneSignalXCFramework (= 5.0.0-alpha-02)
+  - OneSignalXCFramework (= 5.0.0-beta-01)
 
 SPEC REPOS:
   trunk:
@@ -45,9 +45,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  onesignal_flutter: c4fe7cfb99196ccc89ecaef890bdd66abf00f5d7
-  OneSignalXCFramework: 8eec9904167f8c97c23c441709b648f353d22a41
+  onesignal_flutter: e369a8100290b3680412e27e91255916dd23ca22
+  OneSignalXCFramework: 7d3eb90c3e78908b0d72aa88600bfdab694460ec
 
-PODFILE CHECKSUM: f0497bd2adc984c2ee14f5ec68f1959c4d6f7a55
+PODFILE CHECKSUM: 004b8b86fe167483a0c84378eebc1addff2ac31b
 
 COCOAPODS: 1.11.3

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
 
     OneSignal.Debug.setLogLevel(OSLogLevel.debug);
 
-    OneSignal.Debug.setVisualLevel(OSLogLevel.none);
+    OneSignal.Debug.setAlertLevel(OSLogLevel.none);
 
     // NOTE: Replace with your own app ID from https://www.onesignal.com
     OneSignal.shared.initialize("77e32082-ea27-42e3-a898-c72e141824ef");
@@ -189,29 +189,22 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
     if (_emailAddress == null) return;
     print("Remove email");
 
-    OneSignal.User.removeEmail(_emailAddress!).then((response) {
-      print("Successfully remove email with response $response");
-    }).catchError((error) {
-      print("Failed to remove email: $error");
-    });
+    OneSignal.User.removeEmail(_emailAddress!);
   }
 
   void _handleSetSMSNumber() {
     if (_smsNumber == null) return;
     print("Setting SMS Number");
 
-    OneSignal.User.addSmsNumber(_smsNumber!);
+    OneSignal.User.addSms(_smsNumber!);
   }
 
   void _handleRemoveSMSNumber() {
     if (_smsNumber == null) return;
     print("Remove smsNumber");
 
-    OneSignal.User.removeSmsNumber(_smsNumber!).then((response) {
-      print("Successfully remove smsNumber with response $response");
-    }).catchError((error) {
-      print("Failed to remove SMSNumber: $error");
-    });
+    OneSignal.User.removeSms(_smsNumber!);
+
   }
 
   void _handleConsent() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,7 +11,7 @@ class MyApp extends StatefulWidget {
   _MyAppState createState() => new _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
   String _debugLabelString = "";
   String? _emailAddress;
   String? _smsNumber;
@@ -32,12 +32,14 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     if (!mounted) return;
 
-    OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
+    OneSignal.Debug.setLogLevel(OSLogLevel.debug);
 
-    OneSignal.Debug.setVisualLevel(OSLogLevel.verbose);
+    OneSignal.Debug.setVisualLevel(OSLogLevel.none);
 
     // NOTE: Replace with your own app ID from https://www.onesignal.com
     OneSignal.shared.initialize("77e32082-ea27-42e3-a898-c72e141824ef");
+
+    OneSignal.User.pushSubscription.addObserver(this);
 
     // OneSignal.shared.setRequiresUserPrivacyConsent(_requireConsent);
 
@@ -124,6 +126,10 @@ class _MyAppState extends State<MyApp> {
 
     // bool userProvidedPrivacyConsent = await OneSignal.shared.userProvidedPrivacyConsent();
     // print("USER PROVIDED PRIVACY CONSENT: $userProvidedPrivacyConsent");
+  }
+
+  void onOSPushSubscriptionChangedWithStateChanges(OSPushSubscriptionStateChanges stateChanges) {
+    print(stateChanges.jsonRepresentation());
   }
 
   void _handleGetTags() {
@@ -359,6 +365,14 @@ class _MyAppState extends State<MyApp> {
       // print(outcomeEvent.jsonRepresentation());
   }
 
+  void _handleOptIn() {
+     OneSignal.User.pushSubscription.optIn();
+  } 
+
+  void _handleOptOut() {
+    OneSignal.User.pushSubscription.optOut();
+  } 
+
   @override
   Widget build(BuildContext context) {
     return new MaterialApp(
@@ -519,6 +533,14 @@ class _MyAppState extends State<MyApp> {
                       child: new Text(_debugLabelString),
                       alignment: Alignment.center,
                     )
+                  ]),
+                  new TableRow(children: [
+                    new OneSignalButton(
+                        "Opt In", _handleOptIn, !_enableConsentButton)
+                  ]),
+                  new TableRow(children: [
+                    new OneSignalButton(
+                        "Opt Out", _handleOptOut, !_enableConsentButton)
                   ]),
                 ],
               ),

--- a/ios/Classes/OSFlutterDebug.m
+++ b/ios/Classes/OSFlutterDebug.m
@@ -43,8 +43,8 @@
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"OneSignal#setLogLevel" isEqualToString:call.method])
         [self setLogLevel:call];
-    else if ([@"OneSignal#setVisualLevel" isEqualToString:call.method])
-        [self setVisualLevel:call];
+    else if ([@"OneSignal#setAlertLevel" isEqualToString:call.method])
+        [self setAlertLevel:call];
     else 
         result(FlutterMethodNotImplemented);
 }
@@ -54,9 +54,9 @@
     [OneSignal.Debug setLogLevel:logLevel];
 }
 
-- (void)setVisualLevel:(FlutterMethodCall *)call {
+- (void)setAlertLevel:(FlutterMethodCall *)call {
     ONE_S_LOG_LEVEL visualLogLevel = (ONE_S_LOG_LEVEL)[call.arguments[@"visualLevel"] intValue];
-    [OneSignal.Debug setVisualLevel:visualLogLevel];
+    [OneSignal.Debug setAlertLevel:visualLogLevel];
 }
 
 @end

--- a/ios/Classes/OSFlutterNotifications.h
+++ b/ios/Classes/OSFlutterNotifications.h
@@ -34,4 +34,8 @@
 
 @property (strong, nonatomic) FlutterMethodChannel *channel;
 
+@property (atomic) BOOL hasSetNotificationWillShowInForegroundHandler;
+@property (strong, nonatomic) NSMutableDictionary* notificationCompletionCache;
+@property (strong, nonatomic) NSMutableDictionary* receivedNotificationCache;
+
 @end

--- a/ios/Classes/OSFlutterNotifications.h
+++ b/ios/Classes/OSFlutterNotifications.h
@@ -1,0 +1,37 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+#import <OneSignalNotifications/OneSignalNotifications.h>
+
+@interface OSFlutterNotifications : NSObject<FlutterPlugin, OSPermissionObserver>
+
+@property (strong, nonatomic) FlutterMethodChannel *channel;
+
+@end

--- a/ios/Classes/OSFlutterNotifications.m
+++ b/ios/Classes/OSFlutterNotifications.m
@@ -1,0 +1,85 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2023 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OSFlutterNotifications.h"
+#import <OneSignalFramework/OneSignalFramework.h>
+#import <OneSignalNotifications/OneSignalNotifications.h>
+#import "OSFlutterCategories.h"
+
+@implementation OSFlutterNotifications
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    OSFlutterNotifications *instance = [OSFlutterNotifications new];
+
+    instance.channel = [FlutterMethodChannel
+                        methodChannelWithName:@"OneSignal#notifications"
+                        binaryMessenger:[registrar messenger]];
+
+    [registrar addMethodCallDelegate:instance channel:instance.channel];
+    //  NSLog(@"OSFlutterPushSubscription initialized");
+
+    //  [OneSignal.Notifications addPermissionObserver:self];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result { 
+    if ([@"OneSignal#permission" isEqualToString:call.method])
+        result(@([OneSignal.Notifications permission]));
+    else if ([@"OneSignal#canRequest" isEqualToString:call.method])
+        result(@([OneSignal.Notifications canRequestPermission]));
+    else if ([@"OneSignal#clearAll" isEqualToString:call.method])
+        [self clearAll:call withResult:result];
+    else if ([@"OneSignal#requestPermission" isEqualToString:call.method])
+        [self requestPermission:call withResult:result];
+    else
+        result(FlutterMethodNotImplemented);
+}
+
+- (void)clearAll:(FlutterMethodCall *)call  withResult:(FlutterResult)result {
+    [OneSignal.Notifications clearAll];
+    result(nil);
+}
+
+- (void)requestPermission:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL fallbackToSettings = [call.arguments[@"fallbackToSettings"] boolValue];
+    
+    [OneSignal.Notifications requestPermission:^(BOOL accepted) {
+       result(@(accepted));
+    } fallbackToSettings:fallbackToSettings];
+}
+
+- (void)onOSPermissionChanged:(OSPermissionState*)state {
+    // Example of detecting the curret permission
+    if (state.reachable == true) {
+        NSLog(@"Device has permission to display notifications");
+    } else {
+        NSLog(@"Device does not have permission to display notifications");
+    }
+    // prints out all properties
+    NSLog(@"PermissionState:\n%@", state);
+}
+
+
+@end

--- a/ios/Classes/OSFlutterNotifications.m
+++ b/ios/Classes/OSFlutterNotifications.m
@@ -53,6 +53,10 @@
         [self clearAll:call withResult:result];
     else if ([@"OneSignal#requestPermission" isEqualToString:call.method])
         [self requestPermission:call withResult:result];
+    else  if ([@"OneSignal#registerForProvisionalAuthorization" isEqualToString:call.method])
+        [self registerForProvisionalAuthorization:call withResult:result];
+    else if ([@"OneSignal#initNotificationOpenedHandlerParams" isEqualToString:call.method])
+        [self initNotificationOpenedHandlerParams];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -70,6 +74,12 @@
     } fallbackToSettings:fallbackToSettings];
 }
 
+- (void)registerForProvisionalAuthorization:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.Notifications registerForProvisionalAuthorization:^(BOOL accepted) {
+       result(@(accepted));
+    }];
+}
+
 - (void)onOSPermissionChanged:(OSPermissionState*)state {
     // Example of detecting the curret permission
     if (state.reachable == true) {
@@ -79,6 +89,17 @@
     }
     // prints out all properties
     NSLog(@"PermissionState:\n%@", state);
+}
+
+- (void)initNotificationOpenedHandlerParams {
+    [OneSignal.Notifications setNotificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
+        [self handleNotificationOpened:result];
+    }];
+}
+
+#pragma mark Opened Notification Handlers
+- (void)handleNotificationOpened:(OSNotificationOpenedResult *)result {
+    [self.channel invokeMethod:@"OneSignal#handleOpenedNotification" arguments:result.toJson];
 }
 
 

--- a/ios/Classes/OSFlutterPushSubscription.h
+++ b/ios/Classes/OSFlutterPushSubscription.h
@@ -1,0 +1,37 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+#import <OneSignalUser/OneSignalUser.h>
+
+@interface OSFlutterPushSubscription : NSObject<FlutterPlugin, OSPushSubscriptionObserver>
+
+@property (strong, nonatomic) FlutterMethodChannel *channel;
+
+@end

--- a/ios/Classes/OSFlutterPushSubscription.m
+++ b/ios/Classes/OSFlutterPushSubscription.m
@@ -31,6 +31,7 @@
 #import "OSFlutterCategories.h"
 
 @implementation OSFlutterPushSubscription
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     OSFlutterPushSubscription *instance = [OSFlutterPushSubscription new];
 
@@ -72,7 +73,6 @@
 
 - (void)addObserver:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     [OneSignal.User.pushSubscription addObserver:self];
-    NSLog(@"addObserver");
     result(nil);
 }
 
@@ -83,9 +83,7 @@
 }
 
 - (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges*)stateChanges {
-    [self.channel invokeMethod:@"OneSignal#pushSubscriptionChanged" arguments:stateChanges.toDictionary];
-    NSLog(@"onOSPushSubscriptionChangedWithStateChanges");
-   // NSLog(@"PushSubscriptionStateChanges:\n%@", stateChanges);
+    [self.channel invokeMethod:@"OneSignal#pushSubscriptionChanged" arguments:stateChanges.jsonRepresentation];
 }
 
 @end

--- a/ios/Classes/OSFlutterPushSubscription.m
+++ b/ios/Classes/OSFlutterPushSubscription.m
@@ -1,0 +1,92 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2023 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OSFlutterPushSubscription.h"
+#import <OneSignalFramework/OneSignalFramework.h>
+#import <OneSignalUser/OneSignalUser.h>
+#import "OSFlutterCategories.h"
+
+@implementation OSFlutterPushSubscription
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    OSFlutterPushSubscription *instance = [OSFlutterPushSubscription new];
+
+    instance.channel = [FlutterMethodChannel
+                        methodChannelWithName:@"OneSignal#pushsubscription"
+                        binaryMessenger:[registrar messenger]];
+
+    [registrar addMethodCallDelegate:instance channel:instance.channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+    if ([@"OneSignal#pushSubscriptionId" isEqualToString:call.method])
+        result(OneSignal.User.pushSubscription.id);
+    else if ([@"OneSignal#pushSubscriptionToken" isEqualToString:call.method])
+        result(OneSignal.User.pushSubscription.token);
+    else if ([@"OneSignal#pushSubscriptionOptedIn" isEqualToString:call.method])
+        result(@(OneSignal.User.pushSubscription.optedIn));
+    else if ([@"OneSignal#optIn" isEqualToString:call.method])
+        [self optIn:call withResult:result];
+    else if ([@"OneSignal#optOut" isEqualToString:call.method])
+        [self optOut:call withResult:result];
+    else if ([@"OneSignal#addObserver" isEqualToString:call.method])
+        [self addObserver:call withResult:result];
+    else if ([@"OneSignal#removeObserver" isEqualToString:call.method])
+        [self removeObserver:call withResult:result];
+    else
+        result(FlutterMethodNotImplemented);
+}
+
+- (void)optIn:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.User.pushSubscription optIn];
+    result(nil);
+}
+
+- (void)optOut:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.User.pushSubscription optOut];
+    result(nil);
+}
+
+- (void)addObserver:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.User.pushSubscription addObserver:self];
+    NSLog(@"addObserver");
+    result(nil);
+}
+
+// TODO: possibly don't need
+- (void)removeObserver:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.User.pushSubscription removeObserver:self];
+    result(nil);
+}
+
+- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges*)stateChanges {
+    [self.channel invokeMethod:@"OneSignal#pushSubscriptionChanged" arguments:stateChanges.toDictionary];
+    NSLog(@"onOSPushSubscriptionChangedWithStateChanges");
+   // NSLog(@"PushSubscriptionStateChanges:\n%@", stateChanges);
+}
+
+@end
+

--- a/ios/Classes/OSFlutterUser.m
+++ b/ios/Classes/OSFlutterUser.m
@@ -29,6 +29,7 @@
 #import <OneSignalFramework/OneSignalFramework.h>
 #import <OneSignalUser/OneSignalUser.h>
 #import "OSFlutterCategories.h"
+#import "OSFlutterPushSubscription.h"
 
 
 @implementation OSFlutterUser
@@ -40,6 +41,7 @@
                         binaryMessenger:[registrar messenger]];
 
     [registrar addMethodCallDelegate:instance channel:instance.channel];
+    [OSFlutterPushSubscription registerWithRegistrar:registrar];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/ios/Classes/OSFlutterUser.m
+++ b/ios/Classes/OSFlutterUser.m
@@ -67,10 +67,10 @@
         [self addEmail:call];
     else if ([@"OneSignal#removeEmail" isEqualToString:call.method])
         [self removeEmail:call withResult:result];
-    else if ([@"OneSignal#addSmsNumber" isEqualToString:call.method])
-        [self addSmsNumber:call];
-    else if ([@"OneSignal#removeSmsNumber" isEqualToString:call.method])
-        [self removeSmsNumber:call withResult:result];
+    else if ([@"OneSignal#addSms" isEqualToString:call.method])
+        [self addSms:call];
+    else if ([@"OneSignal#removeSms" isEqualToString:call.method])
+        [self removeSms:call withResult:result];
     
     else
         result(FlutterMethodNotImplemented);
@@ -138,17 +138,19 @@
 
 - (void)removeEmail:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSString *email = call.arguments[@"email"];
-    result(@([OneSignal.User removeEmail:email]));
+    [OneSignal.User removeEmail:email];
+    result(nil);
 }
 
-- (void)addSmsNumber:(FlutterMethodCall *)call {
+- (void)addSms:(FlutterMethodCall *)call {
     NSString *smsNumber = call.arguments;
-    [OneSignal.User addSmsNumber:smsNumber];
+    [OneSignal.User addSms:smsNumber];
 }
 
-- (void)removeSmsNumber:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+- (void)removeSms:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSString *smsNumber = call.arguments[@"smsNumber"];
-    result(@([OneSignal.User removeSmsNumber:smsNumber]));
+    [OneSignal.User removeSms:smsNumber];
+    result(nil);
 }
 
 

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -29,6 +29,7 @@
 #import "OSFlutterCategories.h"
 #import "OSFlutterDebug.h"
 #import "OSFlutterUser.h"
+#import "OSFlutterNotifications.h"
 
 
 @interface OneSignalPlugin ()
@@ -70,6 +71,8 @@
     [registrar addMethodCallDelegate:OneSignalPlugin.sharedInstance channel:OneSignalPlugin.sharedInstance.channel];
     [OSFlutterDebug registerWithRegistrar:registrar];
     [OSFlutterUser registerWithRegistrar:registrar];
+    [OSFlutterNotifications registerWithRegistrar:registrar];
+    
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.0.0-alpha-02'
+  s.version          = '5.0.0-beta-01'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.0.0-alpha-02'
+  s.dependency 'OneSignalXCFramework', '5.0.0-beta-01'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -6,14 +6,12 @@ import 'package:onesignal_flutter/src/defines.dart';
 import 'package:onesignal_flutter/src/utils.dart';
 import 'package:onesignal_flutter/src/debug.dart';
 import 'package:onesignal_flutter/src/user.dart';
+import 'package:onesignal_flutter/src/notifications.dart';
 
 export 'src/permission.dart';
 export 'src/defines.dart';
-
-
-// Handlers for various events
-typedef void PermissionChangeHandler(OSPermissionStateChanges changes);
-
+export 'src/pushsubscription.dart';
+export 'src/subscription.dart';
 
 class OneSignal {
   /// A singleton representing the OneSignal SDK.
@@ -23,6 +21,7 @@ class OneSignal {
   static OneSignal shared = new OneSignal();
   static OneSignalDebug Debug = new OneSignalDebug();
   static OneSignalUser User = new OneSignalUser();
+  static OneSignalNotifications Notifications = new OneSignalNotifications();
   
 
   // private channels used to bridge to ObjC/Java

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -21,8 +21,8 @@ class OneSignalDebug {
   ///
   /// The parameter [visualLevel] controls
   /// if the SDK will show alerts for each logged message
-  void setVisualLevel( OSLogLevel visualLevel) {
-    _channel.invokeMethod("OneSignal#setVisualLevel",
+  void setAlertLevel( OSLogLevel visualLevel) {
+    _channel.invokeMethod("OneSignal#setAlertLevel",
         {'visualLevel': visualLevel.index});
   }
 }

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -381,13 +381,15 @@ class OSAndroidBackgroundImageLayout extends JSONStringRepresentable {
   }
 }
 
-// class OSNotificationReceivedEvent extends JSONStringRepresentable {
+class OSNotificationReceivedEvent extends JSONStringRepresentable {
 
-//   late OSNotification notification;
+  late OSNotification notification;
 
-//   OSNotificationReceivedEvent(Map<String, dynamic> json) {
-//     notification = OSNotification(json);
-//   }
+  OSNotificationReceivedEvent(Map<String, dynamic> json) {
+    notification = OSNotification(json);
+  }
+
+  //TODO: remove
 
 //   void complete(OSNotification? notification) {
 //     print('OSNotificationReceivedEvent complete with notification: $notification');
@@ -398,9 +400,9 @@ class OSAndroidBackgroundImageLayout extends JSONStringRepresentable {
 //     }
 //   }
 
-//   String jsonRepresentation() {
-//     return convertToJsonString({
-//       'notification': this.notification.jsonRepresentation()
-//     });
-//   }
-// }
+  String jsonRepresentation() {
+    return convertToJsonString({
+      'notification': this.notification.jsonRepresentation()
+    });
+  }
+}

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -1,0 +1,406 @@
+import 'package:onesignal_flutter/src/defines.dart';
+import 'package:onesignal_flutter/src/utils.dart';
+import 'package:onesignal_flutter/onesignal_flutter.dart';
+import 'package:flutter/foundation.dart';
+import 'dart:convert';
+
+/// A class representing the notification, including the
+/// payload of the notification as well as additional
+/// parameters (such as whether the notification was `shown`
+/// to the user, whether it's `silent`, etc.)
+class OSNotification extends JSONStringRepresentable {
+
+  /// The OneSignal notification ID for this notification
+  late String notificationId;
+
+  /// If this notification was created from a Template on the
+  /// OneSignal dashboard, this will be the ID of that template
+  String? templateId;
+
+  /// The name of the template (if any) that was used to
+  /// create this push notification
+  String? templateName;
+
+  /// The sound file (ie. ping.aiff) that should be played
+  /// when the notification is received
+  String? sound;
+
+  /// The title for the notification
+  String? title;
+
+  /// The body (should contain most of the text)
+  String? body;
+
+  /// If set, he launch URL will be opened when the user
+  /// taps on your push notification. You can control
+  /// whether or not it opens in an in-app webview or
+  /// in Safari (with iOS).
+  String? launchUrl;
+
+  /// Any additional custom data you want to send along
+  /// with this notification.
+  Map<String, dynamic>? additionalData;
+
+  /// Any buttons you want to add to the notification.
+  /// The notificationOpened handler will provide an
+  /// OSNotificationAction object, which will contain
+  /// the ID of the Action the user tapped.
+  List<OSActionButton>? buttons;
+
+  /// A hashmap object representing the raw key/value
+  /// properties of the push notification
+  Map<String, dynamic>? rawPayload;
+
+  /// (iOS Only)
+  /// Any attachments (images, sounds, videos) you want
+  /// to display with this notification.
+  Map<String, dynamic>? attachments;
+
+  /// (iOS Only)
+  /// Tells the system to launch your app in the background (ie. if
+  /// content is available to download in the background)
+  bool? contentAvailable;
+
+  /// (iOS Only)
+  /// Tells the system to launch the Notification Extension Service
+  bool? mutableContent;
+
+  /// (iOS Only)
+  /// The category for this notification. This can trigger custom
+  /// behavior (ie. if this notification should display a
+  /// custom Content Extension for custom UI)
+  String? category;
+
+  /// (iOS Only)
+  /// If you set the badge to a specific value, this integer
+  /// property will be that value
+  int? badge;
+
+  /// (iOS Only)
+  /// If you want to increment the badge by some value, this
+  /// integer will be the increment/decrement
+  int? badgeIncrement;
+
+  /// (iOS Only)
+  /// The subtitle of the notification
+  String? subtitle;
+
+  /// (iOS Only)
+  /// value between 0 and 1 for sorting notifications in a notification summary
+  double? relevanceScore;
+
+  /// (iOS Only)
+  /// The interruption level for the notification. This controls how the
+  /// notification will be displayed to the user if they are using focus modes
+  /// or notification summaries
+  String? interruptionLevel;
+
+  /// (Android Only)
+  /// Summary notifications grouped
+  /// Notification payload will have the most recent notification received.
+  List<OSNotification>? groupedNotifications;
+
+  /// (Android Only)
+  /// The android notification ID (not same as  the OneSignal
+  /// notification ID)
+  int? androidNotificationId;
+
+  /// (Android Only)
+  /// The filename of the image to use as the small
+  /// icon for the notification
+  String? smallIcon;
+
+  /// (Android Only)
+  /// The filename for the image to use as the large
+  /// icon for the notification
+  String? largeIcon;
+
+  /// (Android Only)
+  /// The URL or filename for the image to use as
+  /// the big picture for the notification
+  String? bigPicture;
+
+  /// (Android Only)
+  /// The accent color to use on the notification
+  /// Hex value in ARGB format (it's a normal
+  /// hex color value, but it includes the alpha
+  /// channel in addition to red, green, blue)
+  String? smallIconAccentColor;
+
+  /// (Android Only)
+  /// The color to use to light up the LED (if
+  /// applicable) when the notification is received
+  /// Given in hex ARGB format.
+  String? ledColor;
+
+  /// (Android only) API level 21+
+  /// Sets the visibility of the notification
+  ///  1 = Public (default)
+  ///  0 = Private (hidden from lock screen
+  ///    if user set 'Hide Sensitive content')
+  ///  -1 = Secret (doesn't appear at all)
+  int? lockScreenVisibility;
+
+  /// (Android only)
+  /// All notifications with the same group key
+  /// from the same app will be grouped together
+  String? groupKey;
+
+  /// (Android only) Android 6 and earlier only
+  /// The message to display when multiple
+  /// notifications have been stacked together.
+  /// Note: Android 7 allows groups (stacks)
+  /// to be expanded, so group message is no
+  /// longer necessary
+  String? groupMessage;
+
+  /// (Android Only)
+  /// Tells you what project number/sender ID
+  /// the notification was sent from
+  String? fromProjectNumber;
+
+  /// (Android Only)
+  /// The collapse ID for the notification
+  /// As opposed to groupKey (which causes stacking),
+  /// the collapse ID will completely replace any
+  /// previously received push notifications that
+  /// use the same collapse_id
+  String? collapseId;
+
+  /// (Android Only)
+  /// The priority used with GCM/FCM to describe how
+  /// urgent the notification is. A higher priority
+  /// means the notification will be delivered faster.
+  /// Default = 10.
+  int? priority;
+
+  /// (Android Only)
+  /// Describes the background image layout of the
+  /// notification (if set)
+  OSAndroidBackgroundImageLayout? backgroundImageLayout;
+
+  //converts JSON map to OSNotification instance
+  OSNotification(Map<String, dynamic> json) {
+    // iOS Specific Parameters
+    if (json.containsKey('contentAvailable'))
+      this.contentAvailable = json['contentAvailable'] as bool?;
+    if (json.containsKey('mutableContent'))
+      this.mutableContent = json['mutableContent'] as bool?;
+    if (json.containsKey('category'))
+      this.category = json['category'] as String?;
+    if (json.containsKey('badge')) 
+      this.badge = json['badge'] as int?;
+    if (json.containsKey('badgeIncrement'))
+      this.badgeIncrement = json['badgeIncrement'] as int?;
+    if (json.containsKey('subtitle'))
+      this.subtitle = json['subtitle'] as String?;
+    if (json.containsKey('attachments'))
+      this.attachments = json['attachments'].cast<String, dynamic>();
+    if (json.containsKey('relevanceScore'))
+      this.relevanceScore = json['relevanceScore'] as double?;
+    if (json.containsKey('interruptionLevel'))
+      this.interruptionLevel = json['interruptionLevel'] as String?;
+
+    // Android Specific Parameters
+    if (json.containsKey("smallIcon"))
+      this.smallIcon = json['smallIcon'] as String?;
+    if (json.containsKey("largeIcon"))
+      this.largeIcon = json['largeIcon'] as String?;
+    if (json.containsKey("bigPicture"))
+      this.bigPicture = json['bigPicture'] as String?;
+    if (json.containsKey("smallIconAccentColor"))
+      this.smallIconAccentColor = json['smallIconAccentColor'] as String?;
+    if (json.containsKey("ledColor"))
+      this.ledColor = json['ledColor'] as String?;
+    if (json.containsKey("lockScreenVisibility"))
+      this.lockScreenVisibility = json['lockScreenVisibility'] as int?;
+    if (json.containsKey("groupMessage"))
+      this.groupMessage = json['groupMessage'] as String?;
+    if (json.containsKey("groupKey"))
+      this.groupKey = json['groupKey'] as String?;
+    if (json.containsKey("fromProjectNumber"))
+      this.fromProjectNumber = json['fromProjectNumber'] as String?;
+    if (json.containsKey("collapseId"))
+      this.collapseId = json['collapseId'] as String?;
+    if (json.containsKey("priority")) 
+      this.priority = json['priority'] as int?;
+    if (json.containsKey("androidNotificationId"))
+      this.androidNotificationId = json['androidNotificationId'] as int?;
+    if (json.containsKey('backgroundImageLayout')) {
+      this.backgroundImageLayout = OSAndroidBackgroundImageLayout(
+          json['backgroundImageLayout'].cast<String, dynamic>());
+    }
+    if (json.containsKey('groupedNotifications')) {
+      final dynamic jsonGroupedNotifications = json['groupedNotifications'];
+      final jsonList = jsonDecode(jsonGroupedNotifications.toString()) as List<dynamic>;
+      this.groupedNotifications = jsonList.map((dynamic item) =>
+          OSNotification(item as Map<String, dynamic>)).toList();
+    }
+    
+    // shared parameters
+    this.notificationId = json['notificationId'] as String;
+
+    if (json.containsKey('templateName'))
+      this.templateName = json['templateName'] as String?;
+    if (json.containsKey('templateId'))
+      this.templateId = json['templateId'] as String?;
+    if (json.containsKey('sound')) 
+      this.sound = json['sound'] as String?;
+    if (json.containsKey('title'))
+      this.title = json['title'] as String?;
+    if (json.containsKey('body')) 
+      this.body = json['body'] as String?;
+    if (json.containsKey('launchUrl'))
+      this.launchUrl = json['launchUrl'] as String?;
+    if (json.containsKey('additionalData'))
+      this.additionalData = json['additionalData'].cast<String, dynamic>();
+
+    // raw payload comes as a JSON string
+    if (json.containsKey('rawPayload')) {
+      var raw = json['rawPayload'] as String;
+      JsonDecoder decoder = JsonDecoder();
+      this.rawPayload = decoder.convert(raw);
+    }
+
+    if (json.containsKey('buttons')) {
+      this.buttons = List<OSActionButton>.empty(growable: true);
+      var btns = json['buttons'] as List<dynamic>;
+      for (var btn in btns) {
+        var serialized = btn.cast<String, dynamic>();
+        this.buttons!.add(OSActionButton.fromJson(serialized));
+      }
+    }
+  }
+
+  String jsonRepresentation() => convertToJsonString(this.rawPayload);
+}
+
+/// An instance of this class represents a user interaction with
+/// your push notification, ie. if they tap a button
+class OSNotificationOpenedResult {
+  //instance properties
+  late OSNotification notification;
+  OSNotificationAction? action;
+
+  //constructor
+  OSNotificationOpenedResult(Map<String, dynamic> json) {
+    this.notification =
+        OSNotification(json['notification'].cast<String, dynamic>());
+
+    if (json.containsKey('action')) {
+      this.action =
+          OSNotificationAction(json['action'].cast<String, dynamic>());
+    }
+  }
+}
+
+/// Represents an action taken on a push notification, such as
+/// tapping the notification (or a button on the notification),
+/// or if your `inFocusDisplayType` is set to true - if they
+/// tapped 'close'.
+class OSNotificationAction {
+  /// An enum that represents whether the user `opened` or
+  /// took a more specific `action` (such as tapping a button
+  /// on the notification)
+  late OSNotificationActionType type;
+
+  /// The ID of the button on your notification
+  /// that the user tapped
+  String? actionId;
+
+  OSNotificationAction(Map<String, dynamic> json) {
+    this.type = OSNotificationActionType.opened;
+    this.actionId = json['id'] as String?;
+
+    if (json.containsKey('type'))
+      this.type = OSNotificationActionType.values[json['type'] as int];
+  }
+}
+
+/// Represents a button sent as part of a push notification
+class OSActionButton extends JSONStringRepresentable {
+  /// The custom unique ID for this button
+  late String id;
+
+  /// The text to display for the button
+  late String text;
+
+  /// (Android only)
+  /// The URL/filename to show as the
+  /// button's icon
+  String? icon;
+
+  OSActionButton({required this.id, required this.text, this.icon});
+
+  OSActionButton.fromJson(Map<String, dynamic> json) {
+    this.id = json['id'] as String;
+    this.text = json['text'] as String;
+
+    if (json.containsKey('icon')) this.icon = json['icon'] as String?;
+  }
+
+  Map<String, dynamic> mapRepresentation() {
+    return {'id': this.id, 'text': this.text, 'icon': this.icon};
+  }
+
+  String jsonRepresentation() {
+    return convertToJsonString(this.mapRepresentation());
+  }
+}
+
+/// (Android Only)
+/// This class represents the background image layout
+/// used for push notifications that show a background image
+class OSAndroidBackgroundImageLayout extends JSONStringRepresentable {
+  /// (Android Only)
+  /// The image URL/filename to show as the background image
+  String? image;
+
+  /// (Android Only)
+  /// The color of the title text
+  String? titleTextColor;
+
+  /// (Android Only)
+  /// The color of the body text
+  String? bodyTextColor;
+
+  OSAndroidBackgroundImageLayout(Map<String, dynamic> json) {
+    if (json.containsKey('image')) this.image = json['image'] as String?;
+    if (json.containsKey('titleTextColor'))
+      this.titleTextColor = json['titleTextColor'] as String?;
+    if (json.containsKey('bodyTextColor'))
+      this.bodyTextColor = json['bodyTextColor'] as String?;
+  }
+
+  String jsonRepresentation() {
+    return convertToJsonString({
+      'image': this.image,
+      'titleTextColor': this.titleTextColor,
+      'bodyTextColor': this.bodyTextColor
+    });
+  }
+}
+
+// class OSNotificationReceivedEvent extends JSONStringRepresentable {
+
+//   late OSNotification notification;
+
+//   OSNotificationReceivedEvent(Map<String, dynamic> json) {
+//     notification = OSNotification(json);
+//   }
+
+//   void complete(OSNotification? notification) {
+//     print('OSNotificationReceivedEvent complete with notification: $notification');
+//     if (notification != null) {
+//         OneSignal.shared.completeNotification(notification.notificationId, true);
+//     } else {
+//         OneSignal.shared.completeNotification(this.notification.notificationId, false);
+//     }
+//   }
+
+//   String jsonRepresentation() {
+//     return convertToJsonString({
+//       'notification': this.notification.jsonRepresentation()
+//     });
+//   }
+// }

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -1,0 +1,17 @@
+
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'package:flutter/services.dart';
+import 'package:onesignal_flutter/src/defines.dart';
+
+class OneSignalNotifications {
+
+  // private channels used to bridge to ObjC/Java
+  MethodChannel _channel = const MethodChannel('OneSignal#notifications');
+
+  Future<bool> setPrivacyConsent(bool fallbackToSettings) async {
+    return await _channel
+        .invokeMethod("OneSignal#requestPermission", {'fallbackToSettings': fallbackToSettings});
+  }
+
+}

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -4,58 +4,102 @@ import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:onesignal_flutter/src/defines.dart';
 import 'package:onesignal_flutter/src/notification.dart';
+import 'package:onesignal_flutter/src/permission.dart';
 
 
 
 typedef void OpenedNotificationHandler(OSNotificationOpenedResult openedResult);
+typedef void NotificationWillShowInForegroundHandler(OSNotificationReceivedEvent event);
 
 
 class OneSignalNotifications {
 
   // event handlers
   OpenedNotificationHandler? _onOpenedNotification;
+  NotificationWillShowInForegroundHandler? _onNotificationWillShowInForegroundHandler;
 
   // private channels used to bridge to ObjC/Java
   MethodChannel _channel = const MethodChannel('OneSignal#notifications');
 
+  List<OneSignalPermissionObserver> _observers = <OneSignalPermissionObserver>[];
   // constructor method
   OneSignalNotifications() {
     this._channel.setMethodCallHandler(_handleMethod);
   }
 
-
+  /// Whether this app has push notification permission.
   Future<bool> permission() async {
     return await _channel
         .invokeMethod("OneSignal#permission");
   }
 
+  /// Whether attempting to request notification permission will show a prompt. 
+  /// Returns true if the device has not been prompted for push notification permission already.
   Future<bool> canRequest() async {
     return await _channel
         .invokeMethod("OneSignal#canRequest");
   }
 
+  /// Removes all OneSignal notifications.
   Future<void> clearAll() async {
     return await _channel
         .invokeMethod("OneSignal#clearAll");
   }
 
+  /// Prompt the user for permission to receive push notifications. This will display the native 
+  /// system prompt to request push notification permission.
   Future<bool> requestPermission(bool fallbackToSettings) async {
      return await _channel.invokeMethod("OneSignal#requestPermission", {'fallbackToSettings' : fallbackToSettings});
   }
 
+  /// Instead of having to prompt the user for permission to send them push notifications, 
+  /// your app can request provisional authorization.
   Future<bool> registerForProvisionalAuthorization(bool fallbackToSettings) async {
      return await _channel.invokeMethod("OneSignal#registerForProvisionalAuthorization");
   }
+
+  /// The OSPermissionObserver.onOSPermissionChanged method will be fired on the passed-in object 
+  /// when a notification permission setting changes. This happens when the user enables or disables 
+  /// notifications for your app from the system settings outside of your app.
+  void addPermssionObserver(OneSignalPermissionObserver observer) {
+    _observers.add(observer);
+  }
+
+  // Remove a push subscription observer that has been previously added.
+  void removePermissionObserver(OneSignalPermissionObserver observer) {
+    _observers.remove(observer);
+  }
+  
 
   Future<Null> _handleMethod(MethodCall call) async {
     if (call.method == 'OneSignal#handleOpenedNotification' &&
         this._onOpenedNotification != null) {
       this._onOpenedNotification!(
           OSNotificationOpenedResult(call.arguments.cast<String, dynamic>()));
-    } else 
-        return null;
+    } else if (call.method == 'OneSignal#handleNotificationWillShowInForeground' &&
+        this._onNotificationWillShowInForegroundHandler != null) {
+      this._onNotificationWillShowInForegroundHandler!(
+          OSNotificationReceivedEvent(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#OSPermissionChanged') {
+      this.onOSPermissionChangedHandler(OSPermissionState(call.arguments.cast<String, dynamic>()));
+    } 
+      return null;
   }
-   
+
+  Future<void> onOSPermissionChangedHandler(OSPermissionState state) async {
+    print("onOSPermissionChanged update in flutter");
+    for (var observer in _observers) {
+       print("onOSPermissionChanged fired");
+      observer.onOSPermissionChanged(state);
+    }
+  }
+
+  /// The notification foreground handler is called whenever a notification arrives
+  /// and the application is in foreground
+  void setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler handler) {
+    _onNotificationWillShowInForegroundHandler = handler;
+    _channel.invokeMethod("OneSignal#initNotificationWillShowInForegroundHandlerParams");
+  } 
 
 
   /// The notification opened handler is called whenever the user opens a
@@ -64,7 +108,8 @@ class OneSignalNotifications {
     _onOpenedNotification = handler;
     _channel.invokeMethod("OneSignal#initNotificationOpenedHandlerParams");
   }
-
-
-
+}
+class OneSignalPermissionObserver {
+  void onOSPermissionChanged(OSPermissionState state) {
+  }
 }

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -3,15 +3,68 @@ import 'dart:async';
 import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:onesignal_flutter/src/defines.dart';
+import 'package:onesignal_flutter/src/notification.dart';
+
+
+
+typedef void OpenedNotificationHandler(OSNotificationOpenedResult openedResult);
+
 
 class OneSignalNotifications {
+
+  // event handlers
+  OpenedNotificationHandler? _onOpenedNotification;
 
   // private channels used to bridge to ObjC/Java
   MethodChannel _channel = const MethodChannel('OneSignal#notifications');
 
-  Future<bool> setPrivacyConsent(bool fallbackToSettings) async {
-    return await _channel
-        .invokeMethod("OneSignal#requestPermission", {'fallbackToSettings': fallbackToSettings});
+  // constructor method
+  OneSignalNotifications() {
+    this._channel.setMethodCallHandler(_handleMethod);
   }
+
+
+  Future<bool> permission() async {
+    return await _channel
+        .invokeMethod("OneSignal#permission");
+  }
+
+  Future<bool> canRequest() async {
+    return await _channel
+        .invokeMethod("OneSignal#canRequest");
+  }
+
+  Future<void> clearAll() async {
+    return await _channel
+        .invokeMethod("OneSignal#clearAll");
+  }
+
+  Future<bool> requestPermission(bool fallbackToSettings) async {
+     return await _channel.invokeMethod("OneSignal#requestPermission", {'fallbackToSettings' : fallbackToSettings});
+  }
+
+  Future<bool> registerForProvisionalAuthorization(bool fallbackToSettings) async {
+     return await _channel.invokeMethod("OneSignal#registerForProvisionalAuthorization");
+  }
+
+  Future<Null> _handleMethod(MethodCall call) async {
+    if (call.method == 'OneSignal#handleOpenedNotification' &&
+        this._onOpenedNotification != null) {
+      this._onOpenedNotification!(
+          OSNotificationOpenedResult(call.arguments.cast<String, dynamic>()));
+    } else 
+        return null;
+  }
+   
+
+
+  /// The notification opened handler is called whenever the user opens a
+  /// OneSignal push notification, or taps an action button on a notification.
+  void setNotificationOpenedHandler(OpenedNotificationHandler handler) {
+    _onOpenedNotification = handler;
+    _channel.invokeMethod("OneSignal#initNotificationOpenedHandlerParams");
+  }
+
+
 
 }

--- a/lib/src/permission.dart
+++ b/lib/src/permission.dart
@@ -1,132 +1,18 @@
-// import 'package:onesignal_flutter/src/subscription.dart';
-// import 'package:onesignal_flutter/src/defines.dart';
-// import 'package:onesignal_flutter/src/utils.dart';
+import 'package:onesignal_flutter/src/subscription.dart';
+import 'package:onesignal_flutter/src/defines.dart';
+import 'package:onesignal_flutter/src/utils.dart';
 
-// class OSPermissionState extends JSONStringRepresentable {
-//   bool hasPrompted = false; // iOS only
-//   bool provisional = false; //iOS only
-//   OSNotificationPermission? status;
+class OSPermissionState extends JSONStringRepresentable {
+  bool permission = false; 
+  OSPermissionState(Map<String, dynamic> json) {
+   if (json.containsKey('permission')) {
+      bool enabled = json['permission'] as bool;
+    }
+  }
 
-//   OSPermissionState(Map<String, dynamic> json) {
-//     if (json.containsKey('status')) {
-//       //ios
-//       this.status = OSNotificationPermission.values[json['status'] as int];
-//     } else if (json.containsKey('enabled')) {
-//       bool enabled = json['enabled'] as bool;
-//       this.status = enabled
-//           ? OSNotificationPermission.authorized
-//           : OSNotificationPermission.denied;
-//     }
-
-//     if (json.containsKey('provisional')) {
-//       this.provisional = json['provisional'] as bool;
-//     } else {
-//       this.provisional = false;
-//     }
-
-//     if (json.containsKey('hasPrompted')) {
-//       this.hasPrompted = json['hasPrompted'] as bool;
-//     } else {
-//       this.hasPrompted = false;
-//     }
-//   }
-
-//   String jsonRepresentation() {
-//     return convertToJsonString({
-//       'hasPrompted': this.hasPrompted,
-//       'provisional': this.provisional,
-//       'status': this.status?.index ?? null
-//     });
-//   }
-// }
-
-// class OSPermissionSubscriptionState extends JSONStringRepresentable {
-//   late OSPermissionState permissionStatus;
-//   late OSSubscriptionState subscriptionStatus;
-//   late OSEmailSubscriptionState emailSubscriptionStatus;
-
-//   OSPermissionSubscriptionState(Map<String, dynamic> json) {
-//     this.permissionStatus =
-//         OSPermissionState(json['permissionStatus'].cast<String, dynamic>());
-//     this.subscriptionStatus =
-//         OSSubscriptionState(json['subscriptionStatus'].cast<String, dynamic>());
-//     this.emailSubscriptionStatus = OSEmailSubscriptionState(
-//         json['emailSubscriptionStatus'].cast<String, dynamic>());
-//   }
-
-//   String jsonRepresentation() {
-//     return convertToJsonString({
-//       'permissionStatus': this.permissionStatus.jsonRepresentation(),
-//       'subscriptionStatus': this.subscriptionStatus.jsonRepresentation(),
-//       'emailSubscriptionStatus':
-//           this.emailSubscriptionStatus.jsonRepresentation()
-//     });
-//   }
-// }
-
-// class OSPermissionStateChanges extends JSONStringRepresentable {
-//   late OSPermissionState from;
-//   late OSPermissionState to;
-
-//   OSPermissionStateChanges(Map<String, dynamic> json) {
-//     if (json.containsKey('from'))
-//       this.from = OSPermissionState(json['from'].cast<String, dynamic>());
-//     if (json.containsKey('to'))
-//       this.to = OSPermissionState(json['to'].cast<String, dynamic>());
-//   }
-
-//   String jsonRepresentation() {
-//     return convertToJsonString({
-//       'from': this.from.jsonRepresentation(),
-//       'to': this.to.jsonRepresentation()
-//     });
-//   }
-// }
-
-// class OSDeviceState extends JSONStringRepresentable {
-
-//   bool hasNotificationPermission = false;
-//   bool pushDisabled = false;
-//   bool subscribed = false;
-//   bool emailSubscribed = false;
-//   bool smsSubscribed = false;
-//   String? userId;
-//   String? pushToken;
-//   String? emailUserId;
-//   String? emailAddress;
-//   String? smsUserId;
-//   String? smsNumber;
-//   OSNotificationPermission? notificationPermissionStatus;
-
-//   OSDeviceState(Map<String, dynamic> json) {
-//     this.hasNotificationPermission = json['hasNotificationPermission'] as bool;
-//     this.pushDisabled = json['pushDisabled'] as bool;
-//     this.subscribed = json['subscribed'] as bool;
-//     this.emailSubscribed = json['emailSubscribed'] as bool;
-//     this.smsSubscribed = json['smsSubscribed'] as bool;
-//     this.userId = json['userId'] as String?;
-//     this.pushToken = json['pushToken'] as String?;
-//     this.emailUserId = json['emailUserId'] as String?;
-//     this.emailAddress = json['emailAddress'] as String?;
-//     this.smsUserId = json['smsUserId'] as String?;
-//     this.smsNumber = json['smsNumber'] as String?;
-//     this.notificationPermissionStatus = json['notificationPermissionStatus'] == null ? null : OSNotificationPermission.values[json['notificationPermissionStatus']];
-//   }
-
-//   String jsonRepresentation() {
-//     return convertToJsonString({
-//       'hasNotificationPermission': this.hasNotificationPermission,
-//       'isPushDisabled': this.pushDisabled,
-//       'isSubscribed': this.subscribed,
-//       'userId': this.userId,
-//       'pushToken': this.pushToken,
-//       'isEmailSubscribed': this.emailSubscribed,
-//       'emailUserId': this.emailUserId,
-//       'emailAddress': this.emailAddress,
-//       'isSMSSubscribed': this.smsSubscribed,
-//       'smsUserId': this.smsUserId,
-//       'smsNumber': this.smsNumber,
-//       'notificationPermissionStatus': this.notificationPermissionStatus?.index,
-//     });
-//   }
-// }
+  String jsonRepresentation() {
+    return convertToJsonString({
+      'permission': this.permission
+    });
+  }
+}

--- a/lib/src/permission.dart
+++ b/lib/src/permission.dart
@@ -1,132 +1,132 @@
-import 'package:onesignal_flutter/src/subscription.dart';
-import 'package:onesignal_flutter/src/defines.dart';
-import 'package:onesignal_flutter/src/utils.dart';
+// import 'package:onesignal_flutter/src/subscription.dart';
+// import 'package:onesignal_flutter/src/defines.dart';
+// import 'package:onesignal_flutter/src/utils.dart';
 
-class OSPermissionState extends JSONStringRepresentable {
-  bool hasPrompted = false; // iOS only
-  bool provisional = false; //iOS only
-  OSNotificationPermission? status;
+// class OSPermissionState extends JSONStringRepresentable {
+//   bool hasPrompted = false; // iOS only
+//   bool provisional = false; //iOS only
+//   OSNotificationPermission? status;
 
-  OSPermissionState(Map<String, dynamic> json) {
-    if (json.containsKey('status')) {
-      //ios
-      this.status = OSNotificationPermission.values[json['status'] as int];
-    } else if (json.containsKey('enabled')) {
-      bool enabled = json['enabled'] as bool;
-      this.status = enabled
-          ? OSNotificationPermission.authorized
-          : OSNotificationPermission.denied;
-    }
+//   OSPermissionState(Map<String, dynamic> json) {
+//     if (json.containsKey('status')) {
+//       //ios
+//       this.status = OSNotificationPermission.values[json['status'] as int];
+//     } else if (json.containsKey('enabled')) {
+//       bool enabled = json['enabled'] as bool;
+//       this.status = enabled
+//           ? OSNotificationPermission.authorized
+//           : OSNotificationPermission.denied;
+//     }
 
-    if (json.containsKey('provisional')) {
-      this.provisional = json['provisional'] as bool;
-    } else {
-      this.provisional = false;
-    }
+//     if (json.containsKey('provisional')) {
+//       this.provisional = json['provisional'] as bool;
+//     } else {
+//       this.provisional = false;
+//     }
 
-    if (json.containsKey('hasPrompted')) {
-      this.hasPrompted = json['hasPrompted'] as bool;
-    } else {
-      this.hasPrompted = false;
-    }
-  }
+//     if (json.containsKey('hasPrompted')) {
+//       this.hasPrompted = json['hasPrompted'] as bool;
+//     } else {
+//       this.hasPrompted = false;
+//     }
+//   }
 
-  String jsonRepresentation() {
-    return convertToJsonString({
-      'hasPrompted': this.hasPrompted,
-      'provisional': this.provisional,
-      'status': this.status?.index ?? null
-    });
-  }
-}
+//   String jsonRepresentation() {
+//     return convertToJsonString({
+//       'hasPrompted': this.hasPrompted,
+//       'provisional': this.provisional,
+//       'status': this.status?.index ?? null
+//     });
+//   }
+// }
 
-class OSPermissionSubscriptionState extends JSONStringRepresentable {
-  late OSPermissionState permissionStatus;
-  late OSSubscriptionState subscriptionStatus;
-  late OSEmailSubscriptionState emailSubscriptionStatus;
+// class OSPermissionSubscriptionState extends JSONStringRepresentable {
+//   late OSPermissionState permissionStatus;
+//   late OSSubscriptionState subscriptionStatus;
+//   late OSEmailSubscriptionState emailSubscriptionStatus;
 
-  OSPermissionSubscriptionState(Map<String, dynamic> json) {
-    this.permissionStatus =
-        OSPermissionState(json['permissionStatus'].cast<String, dynamic>());
-    this.subscriptionStatus =
-        OSSubscriptionState(json['subscriptionStatus'].cast<String, dynamic>());
-    this.emailSubscriptionStatus = OSEmailSubscriptionState(
-        json['emailSubscriptionStatus'].cast<String, dynamic>());
-  }
+//   OSPermissionSubscriptionState(Map<String, dynamic> json) {
+//     this.permissionStatus =
+//         OSPermissionState(json['permissionStatus'].cast<String, dynamic>());
+//     this.subscriptionStatus =
+//         OSSubscriptionState(json['subscriptionStatus'].cast<String, dynamic>());
+//     this.emailSubscriptionStatus = OSEmailSubscriptionState(
+//         json['emailSubscriptionStatus'].cast<String, dynamic>());
+//   }
 
-  String jsonRepresentation() {
-    return convertToJsonString({
-      'permissionStatus': this.permissionStatus.jsonRepresentation(),
-      'subscriptionStatus': this.subscriptionStatus.jsonRepresentation(),
-      'emailSubscriptionStatus':
-          this.emailSubscriptionStatus.jsonRepresentation()
-    });
-  }
-}
+//   String jsonRepresentation() {
+//     return convertToJsonString({
+//       'permissionStatus': this.permissionStatus.jsonRepresentation(),
+//       'subscriptionStatus': this.subscriptionStatus.jsonRepresentation(),
+//       'emailSubscriptionStatus':
+//           this.emailSubscriptionStatus.jsonRepresentation()
+//     });
+//   }
+// }
 
-class OSPermissionStateChanges extends JSONStringRepresentable {
-  late OSPermissionState from;
-  late OSPermissionState to;
+// class OSPermissionStateChanges extends JSONStringRepresentable {
+//   late OSPermissionState from;
+//   late OSPermissionState to;
 
-  OSPermissionStateChanges(Map<String, dynamic> json) {
-    if (json.containsKey('from'))
-      this.from = OSPermissionState(json['from'].cast<String, dynamic>());
-    if (json.containsKey('to'))
-      this.to = OSPermissionState(json['to'].cast<String, dynamic>());
-  }
+//   OSPermissionStateChanges(Map<String, dynamic> json) {
+//     if (json.containsKey('from'))
+//       this.from = OSPermissionState(json['from'].cast<String, dynamic>());
+//     if (json.containsKey('to'))
+//       this.to = OSPermissionState(json['to'].cast<String, dynamic>());
+//   }
 
-  String jsonRepresentation() {
-    return convertToJsonString({
-      'from': this.from.jsonRepresentation(),
-      'to': this.to.jsonRepresentation()
-    });
-  }
-}
+//   String jsonRepresentation() {
+//     return convertToJsonString({
+//       'from': this.from.jsonRepresentation(),
+//       'to': this.to.jsonRepresentation()
+//     });
+//   }
+// }
 
-class OSDeviceState extends JSONStringRepresentable {
+// class OSDeviceState extends JSONStringRepresentable {
 
-  bool hasNotificationPermission = false;
-  bool pushDisabled = false;
-  bool subscribed = false;
-  bool emailSubscribed = false;
-  bool smsSubscribed = false;
-  String? userId;
-  String? pushToken;
-  String? emailUserId;
-  String? emailAddress;
-  String? smsUserId;
-  String? smsNumber;
-  OSNotificationPermission? notificationPermissionStatus;
+//   bool hasNotificationPermission = false;
+//   bool pushDisabled = false;
+//   bool subscribed = false;
+//   bool emailSubscribed = false;
+//   bool smsSubscribed = false;
+//   String? userId;
+//   String? pushToken;
+//   String? emailUserId;
+//   String? emailAddress;
+//   String? smsUserId;
+//   String? smsNumber;
+//   OSNotificationPermission? notificationPermissionStatus;
 
-  OSDeviceState(Map<String, dynamic> json) {
-    this.hasNotificationPermission = json['hasNotificationPermission'] as bool;
-    this.pushDisabled = json['pushDisabled'] as bool;
-    this.subscribed = json['subscribed'] as bool;
-    this.emailSubscribed = json['emailSubscribed'] as bool;
-    this.smsSubscribed = json['smsSubscribed'] as bool;
-    this.userId = json['userId'] as String?;
-    this.pushToken = json['pushToken'] as String?;
-    this.emailUserId = json['emailUserId'] as String?;
-    this.emailAddress = json['emailAddress'] as String?;
-    this.smsUserId = json['smsUserId'] as String?;
-    this.smsNumber = json['smsNumber'] as String?;
-    this.notificationPermissionStatus = json['notificationPermissionStatus'] == null ? null : OSNotificationPermission.values[json['notificationPermissionStatus']];
-  }
+//   OSDeviceState(Map<String, dynamic> json) {
+//     this.hasNotificationPermission = json['hasNotificationPermission'] as bool;
+//     this.pushDisabled = json['pushDisabled'] as bool;
+//     this.subscribed = json['subscribed'] as bool;
+//     this.emailSubscribed = json['emailSubscribed'] as bool;
+//     this.smsSubscribed = json['smsSubscribed'] as bool;
+//     this.userId = json['userId'] as String?;
+//     this.pushToken = json['pushToken'] as String?;
+//     this.emailUserId = json['emailUserId'] as String?;
+//     this.emailAddress = json['emailAddress'] as String?;
+//     this.smsUserId = json['smsUserId'] as String?;
+//     this.smsNumber = json['smsNumber'] as String?;
+//     this.notificationPermissionStatus = json['notificationPermissionStatus'] == null ? null : OSNotificationPermission.values[json['notificationPermissionStatus']];
+//   }
 
-  String jsonRepresentation() {
-    return convertToJsonString({
-      'hasNotificationPermission': this.hasNotificationPermission,
-      'isPushDisabled': this.pushDisabled,
-      'isSubscribed': this.subscribed,
-      'userId': this.userId,
-      'pushToken': this.pushToken,
-      'isEmailSubscribed': this.emailSubscribed,
-      'emailUserId': this.emailUserId,
-      'emailAddress': this.emailAddress,
-      'isSMSSubscribed': this.smsSubscribed,
-      'smsUserId': this.smsUserId,
-      'smsNumber': this.smsNumber,
-      'notificationPermissionStatus': this.notificationPermissionStatus?.index,
-    });
-  }
-}
+//   String jsonRepresentation() {
+//     return convertToJsonString({
+//       'hasNotificationPermission': this.hasNotificationPermission,
+//       'isPushDisabled': this.pushDisabled,
+//       'isSubscribed': this.subscribed,
+//       'userId': this.userId,
+//       'pushToken': this.pushToken,
+//       'isEmailSubscribed': this.emailSubscribed,
+//       'emailUserId': this.emailUserId,
+//       'emailAddress': this.emailAddress,
+//       'isSMSSubscribed': this.smsSubscribed,
+//       'smsUserId': this.smsUserId,
+//       'smsNumber': this.smsNumber,
+//       'notificationPermissionStatus': this.notificationPermissionStatus?.index,
+//     });
+//   }
+// }

--- a/lib/src/pushsubscription.dart
+++ b/lib/src/pushsubscription.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'package:flutter/services.dart';
+import 'package:onesignal_flutter/src/defines.dart';
+import 'package:onesignal_flutter/src/subscription.dart';
+
+class OneSignalPushSubscription {
+
+  MethodChannel _channel = const MethodChannel('OneSignal#pushsubscription');
+
+  List<OneSignalPushSubscriptionObserver> _observers = <OneSignalPushSubscriptionObserver>[];
+  // constructor method
+  OneSignalPushSubscription() {
+    this._channel.setMethodCallHandler(_handleMethod);
+    this._initPushSubscriptionState();
+  }
+
+  void _initPushSubscriptionState() {
+    _channel.invokeMethod("OneSignal#addObserver"); 
+  }
+
+  // TODO: convert these syncronous by capturing an initial state and the following the stateChanges
+
+  /// The readonly push subscription ID.
+  Future<String> id() async {
+    return await _channel.invokeMethod("OneSignal#pushSubscriptionToken");
+  }
+
+  /// The readonly push token.
+  Future<String> token() async {
+    return await _channel.invokeMethod("OneSignal#pushSubscriptionToken");
+  }
+
+  /// Gets a boolean value indicating whether the current user is opted in to push notifications. 
+  /// This returns true when the app has notifications permission and optedOut is called. 
+  /// Note: Does not take into account the existence of the subscription ID and push token. 
+  /// This boolean may return true but push notifications may still not be received by the user.
+  Future<bool> optedIn() async {
+    return await _channel.invokeMethod("OneSignal#pushSubscriptionOptedIn");
+  }
+  // TODO: END
+
+  /// Call this method to receive push notifications on the device or to resume receiving of 
+  /// push notifications after calling optOut. If needed, this method will prompt the user for 
+  /// push notifications permission.
+  Future<void> optIn() async {
+    await _channel.invokeMethod("OneSignal#optIn");
+  }
+
+  /// If at any point you want the user to stop receiving push notifications on the current 
+  /// device (regardless of system-level permission status), you can call this method to opt out.
+  Future<void> optOut() async {
+    await _channel.invokeMethod("OneSignal#optOut");
+  }
+
+  /// The OSPushSubscriptionObserver.onOSPushSubscriptionChanged method will be fired on the passed-in 
+  // object when the push subscription changes. This method returns the current OSPushSubscriptionState 
+  // at the time of adding this observer.
+  void addObserver(OneSignalPushSubscriptionObserver observer) {
+    _observers.add(observer);
+  }
+
+  // Remove a push subscription observer that has been previously added.
+  void removeObserver(OneSignalPushSubscriptionObserver observer) {
+    _observers.remove(observer);
+  }
+  
+  // Private function that gets called by ObjC/Java
+  Future<Null> _handleMethod(MethodCall call) async {
+    if (call.method == 'OneSignal#pushSubscriptionChanged') {
+      this._onSubscriptionChangedHandler(OSPushSubscriptionStateChanges(call.arguments.cast<String, dynamic>()));
+    } 
+    return null;
+  }
+
+  Future<void> _onSubscriptionChangedHandler(OSPushSubscriptionStateChanges stateChanges) async {
+    print("update in flutter");
+    for (var observer in _observers) {
+       print("observer fired");
+      observer.onOSPushSubscriptionChangedWithStateChanges(stateChanges);
+    }
+  }
+}
+
+class OneSignalPushSubscriptionObserver {
+  void onOSPushSubscriptionChangedWithStateChanges(OSPushSubscriptionStateChanges stateChanges) {
+    print("update");
+  }
+}

--- a/lib/src/pushsubscription.dart
+++ b/lib/src/pushsubscription.dart
@@ -74,9 +74,7 @@ class OneSignalPushSubscription {
   }
 
   Future<void> _onSubscriptionChangedHandler(OSPushSubscriptionStateChanges stateChanges) async {
-    print("update in flutter");
     for (var observer in _observers) {
-       print("observer fired");
       observer.onOSPushSubscriptionChangedWithStateChanges(stateChanges);
     }
   }
@@ -84,6 +82,5 @@ class OneSignalPushSubscription {
 
 class OneSignalPushSubscriptionObserver {
   void onOSPushSubscriptionChangedWithStateChanges(OSPushSubscriptionStateChanges stateChanges) {
-    print("update");
   }
 }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -1,38 +1,30 @@
 import 'package:onesignal_flutter/src/utils.dart';
 
+
 /// Represents the current user's subscription state with OneSignal
-class OSSubscriptionState extends JSONStringRepresentable {
-  /// Indicates if you have ever called setSubscription(false) to
-  /// programmatically disable notifications for this user
-  bool isPushDisabled = false;
+class OSPushSubscriptionState extends JSONStringRepresentable {
 
-  /// A boolean parameter that indicates if the  user
-  /// is subscribed to your app with OneSignal
-  /// This is only true if the `userId`, `pushToken`, and
-  /// `isPushDisabled` parameters are defined/true.
-  bool isSubscribed = false;
-
-  /// The current user's User ID (AKA playerID) with OneSignal
-  String? userId; //the user's 'playerId' on OneSignal
+  String? id;
 
   /// The APNS (iOS), GCM/FCM (Android) push token
-  String? pushToken;
+  String? token;
 
-  OSSubscriptionState(Map<String, dynamic> json) {
-    this.isSubscribed = json['isSubscribed'] as bool;
-    this.isPushDisabled = json['isPushDisabled'] as bool;
+  bool optedIn = false;
+  
+  OSPushSubscriptionState(Map<String, dynamic> json) {
 
-    if (json.containsKey('userId')) this.userId = json['userId'] as String?;
-    if (json.containsKey('pushToken'))
-      this.pushToken = json['pushToken'] as String?;
+    if (json.containsKey('id'))
+      this.id = json['id'] as String?;
+    if (json.containsKey('token')) this.token = json['token'] as String?;
+    this.optedIn = json['optedIn'] as bool;
+    
   }
 
   String jsonRepresentation() {
     return convertToJsonString({
-      'isSubscribed': this.isSubscribed,
-      'isPushDisabled': this.isPushDisabled,
-      'pushToken': this.pushToken,
-      'userId': this.userId
+      'id': this.id,
+      'token': this.token,
+      'optedIn': this.optedIn
     });
   }
 }
@@ -40,115 +32,21 @@ class OSSubscriptionState extends JSONStringRepresentable {
 /// An instance of this class describes a change in the user's OneSignal
 /// push notification subscription state, ie. the user subscribed to
 /// push notifications with your app.
-class OSSubscriptionStateChanges extends JSONStringRepresentable {
-  late OSSubscriptionState from;
-  late OSSubscriptionState to;
+class OSPushSubscriptionStateChanges extends JSONStringRepresentable {
+  late OSPushSubscriptionState from;
+  late OSPushSubscriptionState to;
 
-  OSSubscriptionStateChanges(Map<String, dynamic> json) {
+  OSPushSubscriptionStateChanges(Map<String, dynamic> json) {
     if (json.containsKey('from'))
-      this.from = OSSubscriptionState(json['from'].cast<String, dynamic>());
+      this.from = OSPushSubscriptionState(json['from'].cast<String, dynamic>());
     if (json.containsKey('to'))
-      this.to = OSSubscriptionState(json['to'].cast<String, dynamic>());
+      this.to = OSPushSubscriptionState(json['to'].cast<String, dynamic>());
   }
 
   String jsonRepresentation() {
     return convertToJsonString(<String, dynamic>{
       'from': from.jsonRepresentation(),
       'to': to.jsonRepresentation()
-    });
-  }
-}
-
-/// Represents the user's OneSignal email subscription state,
-class OSEmailSubscriptionState extends JSONStringRepresentable {
-  bool subscribed = false;
-  String? emailUserId;
-  String? emailAddress;
-
-  OSEmailSubscriptionState(Map<String, dynamic> json) {
-    this.subscribed = false;
-    if (json.containsKey('emailAddress') && json['emailAddress'] != null)
-      this.emailAddress = json['emailAddress'] as String?;
-
-    if (json.containsKey('emailUserId') && json['emailUserId'] != null) {
-      this.emailUserId = json['emailUserId'] as String?;
-      this.subscribed = true;
-    }
-  }
-
-  String jsonRepresentation() {
-    return convertToJsonString({
-      'subscribed': this.subscribed,
-      'emailUserId': this.emailUserId,
-      'emailAddress': this.emailAddress
-    });
-  }
-}
-
-/// An instance of this class describes a change in the user's
-/// email subscription state with OneSignal
-class OSEmailSubscriptionStateChanges extends JSONStringRepresentable {
-  late OSEmailSubscriptionState from;
-  late OSEmailSubscriptionState to;
-
-  OSEmailSubscriptionStateChanges(Map<String, dynamic> json) {
-    if (json.containsKey('from'))
-      this.from = OSEmailSubscriptionState(json['from'].cast<String, dynamic>());
-    if (json.containsKey('to'))
-      this.to = OSEmailSubscriptionState(json['to'].cast<String, dynamic>());
-  }
-
-  String jsonRepresentation() {
-    return convertToJsonString(<String, dynamic>{
-      'from': this.from.jsonRepresentation(),
-      'to': this.to.jsonRepresentation()
-    });
-  }
-}
-
-/// Represents the user's OneSignal SMS subscription state,
-class OSSMSSubscriptionState extends JSONStringRepresentable {
-  bool subscribed = false;
-  String? smsUserId;
-  String? smsNumber;
-
-  OSSMSSubscriptionState(Map<String, dynamic> json) {
-    this.subscribed = false;
-    if (json.containsKey('smsNumber') && json['smsNumber'] != null)
-      this.smsNumber = json['smsNumber'] as String?;
-
-    if (json.containsKey('smsUserId') && json['smsUserId'] != null) {
-      this.smsUserId = json['smsUserId'] as String?;
-      this.subscribed = true;
-    }
-  }
-
-  String jsonRepresentation() {
-    return convertToJsonString({
-      'subscribed': this.subscribed,
-      'smsUserId': this.smsUserId,
-      'smsNumber': this.smsNumber
-    });
-  }
-}
-
-/// An instance of this class describes a change in the user's
-/// email subscription state with OneSignal
-class OSSMSSubscriptionStateChanges extends JSONStringRepresentable {
-  late OSSMSSubscriptionState from;
-  late OSSMSSubscriptionState to;
-
-  OSSMSSubscriptionStateChanges(Map<String, dynamic> json) {
-    if (json.containsKey('from'))
-      this.from = OSSMSSubscriptionState(json['from'].cast<String, dynamic>());
-    if (json.containsKey('to'))
-      this.to = OSSMSSubscriptionState(json['to'].cast<String, dynamic>());
-  }
-
-  String jsonRepresentation() {
-    return convertToJsonString(<String, dynamic>{
-      'from': this.from.jsonRepresentation(),
-      'to': this.to.jsonRepresentation()
     });
   }
 }

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -84,23 +84,23 @@ class OneSignalUser {
   ///
   /// Returns false if the specified [email] does not exist 
   /// on the user within the SDK, and no request will be made.
-  Future<bool> removeEmail(String email) async {
+  Future<void> removeEmail(String email) async {
     return await _channel.invokeMethod("OneSignal#removeEmail");
   }
 
   /// Add a new SMS subscription to the current user.
   ///
   /// Add an SMS subscription by adding an [smsNumber]
-  void addSmsNumber(String smsNumber) {
-    _channel.invokeMethod("OneSignal#addSmsNumber", smsNumber);
+  void addSms(String smsNumber) {
+    _channel.invokeMethod("OneSignal#addSms", smsNumber);
   }
 
   /// Remove an SMS subscription from the current user. 
   ///
   /// Returns false if the specified [smsNumber] does not
   /// exist on the user within the SDK, and no request will be made.
-  Future<bool> removeSmsNumber(String smsNumber) async {
-    return await _channel.invokeMethod("OneSignal#removeSmsNumber");
+  Future<void> removeSms(String smsNumber) async {
+    return await _channel.invokeMethod("OneSignal#removeSms");
   }
 
 

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -3,7 +3,13 @@ import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:onesignal_flutter/src/defines.dart';
 
+import 'package:onesignal_flutter/src/pushsubscription.dart';
+
 class OneSignalUser {
+
+  static OneSignalPushSubscription _pushSubscription = new OneSignalPushSubscription();
+  // OneSignalPushSubscription _updatedAccount;  
+  OneSignalPushSubscription get pushSubscription => _pushSubscription;
 
   // private channels used to bridge to ObjC/Java
   MethodChannel _channel = const MethodChannel('OneSignal#user');

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -8,7 +8,7 @@ import 'package:onesignal_flutter/src/pushsubscription.dart';
 class OneSignalUser {
 
   static OneSignalPushSubscription _pushSubscription = new OneSignalPushSubscription();
-  // OneSignalPushSubscription _updatedAccount;  
+
   OneSignalPushSubscription get pushSubscription => _pushSubscription;
 
   // private channels used to bridge to ObjC/Java

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.0.0-alpha-02
+version: 5.0.0-beta-01
 author: Brad Hesse <brad@onesignal.com>, Josh Kasten <josh@onesignal.com>
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 


### PR DESCRIPTION
# Description
## One Line Summary
Notification and pushSubscription namespaces for iOS
## Details
### Notifications namespaced methods and OneSignalPermissionObserver

`OneSignal.Notifications.setNotificationOpenedHandler((OSNotificationOpenedResult result) { });`
`OneSignal.Notifications.setNotificationOpenedHandler.setNotificationWillShowInForegroundHandler((OSNotificationReceivedEvent event) {});`
`OneSignal.Notifications.addPermissionObserver(OneSignalPermissionObserver);`
`OneSignal.Notifications.removePermissionObserver(OneSignalPermissionObserver);`
`OneSignal.Notifications.clearAll();`

The following two methods are Async and return a bool
`OneSignal.Notifications.registerForProvisionalAuthorization();`
`OneSignal.Notifications.requestPermission(fallbackToSettings);`


### pushSubscription namespaced methods and OneSignalPushSubscriptionObserver

`OneSignal.User.pushSubscription.addObserver(OneSignalPushSubscriptionObserver);`
`OneSignal.User.pushSubscription.removeObserver(OneSignalPushSubscriptionObserver);`
`OneSignal.User.pushSubscription.optIn();`
`OneSignal.User.pushSubscription.optOut();`

### Note
Need to make the following properties
`OneSignal.User.pushSubscription.id();`
`OneSignal.User.pushSubscription.token();`
`OneSignal.User.pushSubscription.optedIn();`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/646)
<!-- Reviewable:end -->
