### PR TITLE
[User Model] Location Namespace

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -222,7 +222,7 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
 
   void _handleSetLocationShared() {
     print("Setting location shared to true");
-    // OneSignal.shared.setLocationShared(true);
+    OneSignal.Location.setShared(true);
   }
 
   void _handleRemoveTag() {
@@ -440,10 +440,10 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
                 //     new OneSignalButton("Provide GDPR Consent", _handleConsent,
                 //         _enableConsentButton)
                 //   ]),
-                //   new TableRow(children: [
-                //     new OneSignalButton("Set Location Shared",
-                //         _handleSetLocationShared, !_enableConsentButton)
-                //   ]),
+                  new TableRow(children: [
+                    new OneSignalButton("Set Location Shared",
+                        _handleSetLocationShared, !_enableConsentButton)
+                  ]),
                   new TableRow(children: [
                     new OneSignalButton(
                         "Remove Tag", _handleRemoveTag, !_enableConsentButton)

--- a/ios/Classes/OSFlutterLocation.h
+++ b/ios/Classes/OSFlutterLocation.h
@@ -1,0 +1,36 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+
+@interface OSFlutterLocation : NSObject<FlutterPlugin>
+
+@property (strong, nonatomic) FlutterMethodChannel *channel;
+
+@end

--- a/ios/Classes/OSFlutterLocation.m
+++ b/ios/Classes/OSFlutterLocation.m
@@ -1,0 +1,68 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2023 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OSFlutterLocation.h"
+#import <OneSignalFramework/OneSignalFramework.h>
+#import "OSFlutterCategories.h"
+
+@implementation OSFlutterLocation
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    OSFlutterLocation *instance = [OSFlutterLocation new];
+
+    instance.channel = [FlutterMethodChannel
+                        methodChannelWithName:@"OneSignal#location"
+                        binaryMessenger:[registrar messenger]];
+
+    [registrar addMethodCallDelegate:instance channel:instance.channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+    if ([@"OneSignal#requestPermission" isEqualToString:call.method])
+        [self requestPermission:call withResult:result];
+    else if ([@"OneSignal#setShared" isEqualToString:call.method])
+        [self setLocationShared:call withResult:result];
+    else if ([@"OneSignal#isShared" isEqualToString:call.method])
+        result(@([OneSignal.Location isShared]));
+    else
+        result(FlutterMethodNotImplemented);
+}
+
+
+- (void)setLocationShared:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL locationShared = [call.arguments boolValue];
+    [OneSignal.Location setShared:locationShared];
+    result(nil);
+}
+
+- (void)requestPermission:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.Location requestPermission];
+    result(nil);
+}
+
+
+
+@end

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -31,6 +31,7 @@
 #import "OSFlutterUser.h"
 #import "OSFlutterNotifications.h"
 #import "OSFlutterSession.h"
+#import "OSFlutterLocation.h"
 
 
 @interface OneSignalPlugin ()
@@ -74,6 +75,7 @@
     [OSFlutterUser registerWithRegistrar:registrar];
     [OSFlutterNotifications registerWithRegistrar:registrar];
     [OSFlutterSession registerWithRegistrar:registrar];
+    [OSFlutterLocation registerWithRegistrar:registrar];
     
 }
 

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -8,6 +8,7 @@ import 'package:onesignal_flutter/src/debug.dart';
 import 'package:onesignal_flutter/src/user.dart';
 import 'package:onesignal_flutter/src/notifications.dart';
 import 'package:onesignal_flutter/src/session.dart';
+import 'package:onesignal_flutter/src/location.dart';
 
 export 'src/permission.dart';
 export 'src/defines.dart';
@@ -25,6 +26,7 @@ class OneSignal {
   static OneSignalUser User = new OneSignalUser();
   static OneSignalNotifications Notifications = new OneSignalNotifications();
   static OneSignalSession Session = new OneSignalSession();
+  static OneSignalLocation Location = new OneSignalLocation();
   
 
   // private channels used to bridge to ObjC/Java

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'package:flutter/services.dart';
+import 'package:onesignal_flutter/src/defines.dart';
+
+class OneSignalLocation {
+
+  // private channels used to bridge to ObjC/Java
+  MethodChannel _channel = const MethodChannel('OneSignal#location');
+
+   /// Allows you to prompt the user for permission to use location services
+  Future<void> requestPermission() async {
+    return await _channel.invokeMethod("OneSignal#requestPermission");
+  }
+
+  /// Allows you to determine if the user's location data is shared with OneSignal.
+  /// This allows you to do things like geofenced notifications, etc.
+  Future<void> setShared(bool shared) async {
+    return await _channel.invokeMethod("OneSignal#setShared", shared);
+  }
+  
+  /// Set whether location is currently shared with OneSignal.
+  Future<bool> isShared() async {
+    return await _channel.invokeMethod("OneSignal#isShared");
+  }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Adding the location namespace where a developer can request permission and set whether location is shared or not.
## Details
`OneSignal.Location.requestPermission();`
`const shared = OneSignal.Location.isShared()`
`OneSignal.Location.setShared(true);`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/648)
<!-- Reviewable:end -->
