### PR TITLE
[User Model] InAppMessages Namespace + iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,7 +69,7 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
       });
     });  
 
-    OneSignal.InAppMessages.pause(false);
+    OneSignal.InAppMessages.paused(false);
 
     OneSignal.InAppMessages
         .setInAppMessageClickedHandler((OSInAppMessageAction action) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,6 +44,8 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
     // Outcome Examples
     oneSignalOutcomeExamples();
 
+    OneSignal.shared.login("Testtesttest");
+
     // OneSignal.shared.setRequiresUserPrivacyConsent(_requireConsent);
 
     OneSignal.Notifications
@@ -67,48 +69,31 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
       });
     });  
 
-    // OneSignal.shared
-    //     .setInAppMessageClickedHandler((OSInAppMessageAction action) {
-    //     this.setState(() {
-    //     _debugLabelString =
-    //         "In App Message Clicked: \n${action.jsonRepresentation().replaceAll("\\n", "\n")}";
-    //   });
-    // });
+    OneSignal.InAppMessages.pause(false);
 
-    // OneSignal.shared
-    //     .setSubscriptionObserver((OSSubscriptionStateChanges changes) {
-    //   print("SUBSCRIPTION STATE CHANGED: ${changes.jsonRepresentation()}");
-    // });
+    OneSignal.InAppMessages
+        .setInAppMessageClickedHandler((OSInAppMessageAction action) {
+        this.setState(() {
+        _debugLabelString =
+            "In App Message Clicked: \n${action.jsonRepresentation().replaceAll("\\n", "\n")}";
+      });
+    });
 
-    // OneSignal.shared.setPermissionObserver((OSPermissionStateChanges changes) {
-    //   print("PERMISSION STATE CHANGED: ${changes.jsonRepresentation()}");
-    // });
+    OneSignal.InAppMessages.setOnWillDisplayInAppMessageHandler((message) {
+      print("ON WILL DISPLAY IN APP MESSAGE ${message.messageId}");
+    });
 
-    // OneSignal.shared.setEmailSubscriptionObserver(
-    //     (OSEmailSubscriptionStateChanges changes) {
-    //   print("EMAIL SUBSCRIPTION STATE CHANGED ${changes.jsonRepresentation()}");
-    // });
+    OneSignal.InAppMessages.setOnDidDisplayInAppMessageHandler((message) {
+      print("ON DID DISPLAY IN APP MESSAGE ${message.messageId}");
+    });
 
-    // OneSignal.shared.setSMSSubscriptionObserver(
-    //     (OSSMSSubscriptionStateChanges changes) {
-    //   print("SMS SUBSCRIPTION STATE CHANGED ${changes.jsonRepresentation()}");
-    // });
+    OneSignal.InAppMessages.setOnWillDismissInAppMessageHandler((message) {
+      print("ON WILL DISMISS IN APP MESSAGE ${message.messageId}");
+    });
 
-    // OneSignal.shared.setOnWillDisplayInAppMessageHandler((message) {
-    //   print("ON WILL DISPLAY IN APP MESSAGE ${message.messageId}");
-    // });
-
-    // OneSignal.shared.setOnDidDisplayInAppMessageHandler((message) {
-    //   print("ON DID DISPLAY IN APP MESSAGE ${message.messageId}");
-    // });
-
-    // OneSignal.shared.setOnWillDismissInAppMessageHandler((message) {
-    //   print("ON WILL DISMISS IN APP MESSAGE ${message.messageId}");
-    // });
-
-    // OneSignal.shared.setOnDidDismissInAppMessageHandler((message) {
-    //   print("ON DID DISMISS IN APP MESSAGE ${message.messageId}");
-    // });
+    OneSignal.InAppMessages.setOnDidDismissInAppMessageHandler((message) {
+      print("ON DID DISMISS IN APP MESSAGE ${message.messageId}");
+    });
 
     // iOS-only method to open launch URLs in Safari when set to false
     // OneSignal.shared.setLaunchURLsInApp(false);
@@ -160,9 +145,7 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
 
   void _handlePromptForPushPermission() {
     print("Prompting for Permission");
-    // OneSignal.shared.promptUserForPushNotificationPermission().then((accepted) {
-    //   print("Accepted permission: $accepted");
-    // });
+    OneSignal.Notifications.requestPermission(true);
   }
 
   void _handleGetDeviceState() async {
@@ -370,10 +353,10 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
                     new OneSignalButton(
                         "Send Tags", _handleSendTags, !_enableConsentButton)
                   ]),
-                //   new TableRow(children: [
-                //     new OneSignalButton("Prompt for Push Permission",
-                //         _handlePromptForPushPermission, !_enableConsentButton)
-                //   ]),
+                  new TableRow(children: [
+                    new OneSignalButton("Prompt for Push Permission",
+                        _handlePromptForPushPermission, !_enableConsentButton)
+                  ]),
                 //   new TableRow(children: [
                 //     new OneSignalButton(
                 //         "Print Device State",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,8 +69,6 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
       });
     });  
 
-    OneSignal.InAppMessages.paused(false);
-
     OneSignal.InAppMessages
         .setInAppMessageClickedHandler((OSInAppMessageAction action) {
         this.setState(() {
@@ -120,19 +118,6 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
     print(stateChanges.jsonRepresentation());
   }
 
-  void _handleGetTags() {
-    // OneSignal.shared.getTags().then((tags) {
-    //   if (tags == null) return;
-
-    //   setState((() {
-    //     _debugLabelString = "$tags";
-    //   }));
-    // }).catchError((error) {
-    //   setState(() {
-    //     _debugLabelString = "$error";
-    //   });
-    // });
-  }
 
   void _handleSendTags() {
     print("Sending tags");
@@ -141,6 +126,14 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
     print("Sending tags array");
     var sendTags = {'test': 'value', 'test2': 'value2'};
     OneSignal.User.addTags(sendTags);
+  }
+
+  void _handleRemoveTag() {
+    print("Deleting tag");
+    OneSignal.User.removeTag("test2");
+
+    print("Deleting tags array");
+    OneSignal.User.removeTags(['test']);
   }
 
   void _handlePromptForPushPermission() {
@@ -208,13 +201,7 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
     OneSignal.Location.setShared(true);
   }
 
-  void _handleRemoveTag() {
-    print("Deleting tag");
-    OneSignal.User.removeTag("test2");
-
-    print("Deleting tags array");
-    OneSignal.User.removeTags(['test']);
-  }
+  
 
   void _handleSetExternalUserId() {
     print("Setting external user ID");
@@ -287,33 +274,35 @@ class _MyAppState extends State<MyApp> with OneSignalPushSubscriptionObserver {
   }
 
   oneSignalInAppMessagingTriggerExamples() async {
-    // /// Example addTrigger call for IAM
-    // /// This will add 1 trigger so if there are any IAM satisfying it, it
-    // /// will be shown to the user
-    // OneSignal.shared.addTrigger("trigger_1", "one");
+    /// Example addTrigger call for IAM
+    /// This will add 1 trigger so if there are any IAM satisfying it, it
+    /// will be shown to the user
+    OneSignal.InAppMessages.addTrigger("trigger_1", "one");
 
-    // /// Example addTriggers call for IAM
-    // /// This will add 2 triggers so if there are any IAM satisfying these, they
-    // /// will be shown to the user
-    // Map<String, Object> triggers = new Map<String, Object>();
-    // triggers["trigger_2"] = "two";
-    // triggers["trigger_3"] = "three";
-    // OneSignal.shared.addTriggers(triggers);
+    /// Example addTriggers call for IAM
+    /// This will add 2 triggers so if there are any IAM satisfying these, they
+    /// will be shown to the user
+    Map<String, Object> triggers = new Map<String, Object>();
+    triggers["trigger_2"] = "two";
+    triggers["trigger_3"] = "three";
+    OneSignal.InAppMessages.addTriggers(triggers);
 
-    // // Removes a trigger by its key so if any future IAM are pulled with
-    // // these triggers they will not be shown until the trigger is added back
-    // OneSignal.shared.removeTriggerForKey("trigger_2");
+    // Removes a trigger by its key so if any future IAM are pulled with
+    // these triggers they will not be shown until the trigger is added back
+    OneSignal.InAppMessages.removeTrigger("trigger_2");
 
-    // // Get the value for a trigger by its key
-    // Object? triggerValue = await OneSignal.shared.getTriggerValueForKey("trigger_3");
-    // print("'trigger_3' key trigger value: ${triggerValue?.toString()}");
 
-    // // Create a list and bulk remove triggers based on keys supplied
-    // List<String> keys = ["trigger_1", "trigger_3"];
-    // OneSignal.shared.removeTriggersForKeys(keys);
+    // Create a list and bulk remove triggers based on keys supplied
+    List<String> keys = ["trigger_1", "trigger_3"];
+    OneSignal.InAppMessages.removeTriggers(keys);
 
-    // // Toggle pausing (displaying or not) of IAMs
-    // OneSignal.shared.pauseInAppMessages(false);
+    OneSignal.InAppMessages.clearTriggers();
+
+    // Toggle pausing (displaying or not) of IAMs
+    OneSignal.InAppMessages.paused(false);
+    var arePaused = await OneSignal.InAppMessages.arePaused();
+    print('Notifications paused ${arePaused}');
+
   }
 
   oneSignalOutcomeExamples() async {

--- a/ios/Classes/OSFlutterInAppMessages.h
+++ b/ios/Classes/OSFlutterInAppMessages.h
@@ -1,0 +1,44 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+#import <OneSignalFramework/OneSignalFramework.h>
+
+@interface OSFlutterInAppMessages : NSObject<FlutterPlugin, OSInAppMessageLifecycleHandler>
+
+@property (strong, nonatomic) FlutterMethodChannel *channel;
+@property (atomic) BOOL hasSetInAppMessageClickedHandler;
+
+/*
+    Holds reference to any in app messages received before any click action
+    occurs on the body, button or image elements of the in app message
+*/
+@property (strong, nonatomic) OSInAppMessageAction *inAppMessageClickedResult;
+
+@end

--- a/ios/Classes/OSFlutterInAppMessages.h
+++ b/ios/Classes/OSFlutterInAppMessages.h
@@ -33,8 +33,9 @@
 @interface OSFlutterInAppMessages : NSObject<FlutterPlugin, OSInAppMessageLifecycleHandler>
 
 @property (strong, nonatomic) FlutterMethodChannel *channel;
-@property (atomic) BOOL hasSetInAppMessageClickedHandler;
++ (instancetype)sharedInstance;
 
+@property (atomic) BOOL hasSetInAppMessageClickedHandler;
 /*
     Holds reference to any in app messages received before any click action
     occurs on the body, button or image elements of the in app message

--- a/ios/Classes/OSFlutterInAppMessages.m
+++ b/ios/Classes/OSFlutterInAppMessages.m
@@ -1,0 +1,146 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2023 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OSFlutterDebug.h"
+#import <OneSignalFramework/OneSignalFramework.h>
+#import "OSFlutterCategories.h"
+
+@implementation OSFlutterInAppMessages
+
++ (instancetype)sharedInstance {
+    static OSFlutterInAppMessages *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [OSFlutterInAppMessages new];
+        sharedInstance.hasSetInAppMessageClickedHandler = false;
+    });
+    return sharedInstance;
+}
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    OSFlutterInAppMessages *instance = [OSFlutterInAppMessages new];
+
+    instance.channel = [FlutterMethodChannel
+                        methodChannelWithName:@"OneSignal#inappmessages"
+                        binaryMessenger:[registrar messenger]];
+
+    [registrar addMethodCallDelegate:instance channel:instance.channel];
+
+    [OneSignal.InAppMessages setLifecycleHandler:^(OSInAppMessageAction *action) {
+         [self handleInAppMessageClicked:action];
+     }];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+    if ([@"OneSignal#addTrigger" isEqualToString:call.method]) {
+        [self addTriggers:call withResult:result];
+    } else if ([@"OneSignal#addTriggers" isEqualToString:call.method]) {
+        [self addTriggers:call withResult:result];
+    } else if ([@"OneSignal#removeTrigger" isEqualToString:call.method]) {
+        [self removeTrigger:call withResult:result];
+    } else if ([@"OneSignal#removeTriggers" isEqualToString:call.method]) {
+        [self removeTriggers:call withResult:result];
+    } else if ([@"OneSignal#clearTriggers" isEqualToString:call.method]) {
+        result([OneSignal clearTriggers:call.arguments]);
+    } else if ([@"OneSignal#paused" isEqualToString:call.method]) {
+        [self paused:call withResult:result];
+    } else if ([@"OneSignal#arePaused" isEqualToString:call.method]) {
+        result(@([OneSignal paused];))
+    } else if ([@"OneSignal#initInAppMessageClickedHandlerParams" isEqualToString:call.method])
+        [self initInAppMessageClickedHandlerParams];{
+    else
+        result(FlutterMethodNotImplemented);
+    }
+}
+
+- (void)addTriggers:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSDictionary *triggers = call.arguments;
+    [OneSignal.InAppMessages addTriggers:triggers];
+    result(nil);
+}
+
+- (void)removeTrigger:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *key = call.arguments;
+    [OneSignal.InAppMessages removeTrigger:key];
+    result(nil);
+}
+
+- (void)removeTriggers:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSArray *keys = call.arguments;
+    [OneSignal.InAppMessages removeTriggersForKeys:keys];
+    result(nil);
+}
+
+- (void)clearTriggers:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.InAppMessages clearTriggers];
+    result(nil);
+}
+
+- (void)paused:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL pause = [call.arguments boolValue];
+    [OneSignal.InAppMessages paused:pause];
+    result(nil);
+}
+
+
+#pragma mark In App Message Click
+- (void)initInAppMessageClickedHandlerParams {
+    _hasSetInAppMessageClickedHandler = true;
+
+    if (self.inAppMessageClickedResult) {
+        [self handleInAppMessageClicked:self.inAppMessageClickedResult];
+        self.inAppMessageClickedResult = nil;
+    }
+}
+
+- (void)handleInAppMessageClicked:(OSInAppMessageAction *)action {
+    if (!self.hasSetInAppMessageClickedHandler) {
+        _inAppMessageClickedResult = action;
+        return;
+    }
+
+    [self.channel invokeMethod:@"OneSignal#handleClickedInAppMessage" arguments:action.toJson];
+}
+
+#pragma mark OSInAppMessageLifeCycleHandler
+- (void)onWillDisplayInAppMessage:(OSInAppMessage *) result {
+    [self.channel invokeMethod:@"OneSignal#onWillDisplayInAppMessage" arguments:result.toJson];
+}
+
+- (void)onDidDisplayInAppMessage:(OSInAppMessage *) result {
+    [self.channel invokeMethod:@"OneSignal#onDidDisplayInAppMessage" arguments:result.toJson];
+}
+
+- (void)onWillDismissInAppMessage:(OSInAppMessage *) result {
+    [self.channel invokeMethod:@"OneSignal#onWillDismissInAppMessage" arguments:result.toJson];
+}
+
+- (void)onDidDismissInAppMessage:(OSInAppMessage *) result {
+    [self.channel invokeMethod:@"OneSignal#onDidDismissInAppMessage" arguments:result.toJson];
+}
+
+@end

--- a/ios/Classes/OSFlutterInAppMessages.m
+++ b/ios/Classes/OSFlutterInAppMessages.m
@@ -25,7 +25,7 @@
  * THE SOFTWARE.
  */
 
-#import "OSFlutterDebug.h"
+#import "OSFlutterInAppMessages.h"
 #import <OneSignalFramework/OneSignalFramework.h>
 #import "OSFlutterCategories.h"
 
@@ -42,17 +42,17 @@
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-    OSFlutterInAppMessages *instance = [OSFlutterInAppMessages new];
-
-    instance.channel = [FlutterMethodChannel
+   
+    OSFlutterInAppMessages.sharedInstance.channel = [FlutterMethodChannel
                         methodChannelWithName:@"OneSignal#inappmessages"
                         binaryMessenger:[registrar messenger]];
 
-    [registrar addMethodCallDelegate:instance channel:instance.channel];
+    [registrar addMethodCallDelegate:OSFlutterInAppMessages.sharedInstance channel:OSFlutterInAppMessages.sharedInstance.channel];
 
-    [OneSignal.InAppMessages setLifecycleHandler:^(OSInAppMessageAction *action) {
-         [self handleInAppMessageClicked:action];
+    [OneSignal.InAppMessages setClickHandler:^(OSInAppMessageAction *action) {
+         [OSFlutterInAppMessages.sharedInstance handleInAppMessageClicked:action];
      }];
+     [OneSignal.InAppMessages setLifecycleHandler:OSFlutterInAppMessages.sharedInstance];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
@@ -65,14 +65,15 @@
     } else if ([@"OneSignal#removeTriggers" isEqualToString:call.method]) {
         [self removeTriggers:call withResult:result];
     } else if ([@"OneSignal#clearTriggers" isEqualToString:call.method]) {
-        result([OneSignal clearTriggers:call.arguments]);
+          [self clearTriggers:call withResult:result];
     } else if ([@"OneSignal#paused" isEqualToString:call.method]) {
         [self paused:call withResult:result];
     } else if ([@"OneSignal#arePaused" isEqualToString:call.method]) {
-        result(@([OneSignal paused];))
-    } else if ([@"OneSignal#initInAppMessageClickedHandlerParams" isEqualToString:call.method])
-        [self initInAppMessageClickedHandlerParams];{
-    else
+        result(@([OneSignal.InAppMessages paused]));
+    } else if ([@"OneSignal#initInAppMessageClickedHandlerParams" isEqualToString:call.method]) {
+        [self initInAppMessageClickedHandlerParams];
+    }
+    else{
         result(FlutterMethodNotImplemented);
     }
 }
@@ -91,7 +92,7 @@
 
 - (void)removeTriggers:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSArray *keys = call.arguments;
-    [OneSignal.InAppMessages removeTriggersForKeys:keys];
+    [OneSignal.InAppMessages removeTriggers:keys];
     result(nil);
 }
 

--- a/ios/Classes/OSFlutterNotifications.h
+++ b/ios/Classes/OSFlutterNotifications.h
@@ -33,9 +33,10 @@
 @interface OSFlutterNotifications : NSObject<FlutterPlugin, OSPermissionObserver>
 
 @property (strong, nonatomic) FlutterMethodChannel *channel;
-
++ (instancetype)sharedInstance;
 @property (atomic) BOOL hasSetNotificationWillShowInForegroundHandler;
 @property (strong, nonatomic) NSMutableDictionary* notificationCompletionCache;
 @property (strong, nonatomic) NSMutableDictionary* receivedNotificationCache;
+
 
 @end

--- a/ios/Classes/OSFlutterNotifications.m
+++ b/ios/Classes/OSFlutterNotifications.m
@@ -45,13 +45,13 @@
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-    OSFlutterNotifications *instance = [OSFlutterNotifications new];
+    //OSFlutterNotifications *instance = [OSFlutterNotifications new];
 
-    instance.channel = [FlutterMethodChannel
+    OSFlutterNotifications.sharedInstance.channel = [FlutterMethodChannel
                         methodChannelWithName:@"OneSignal#notifications"
                         binaryMessenger:[registrar messenger]];
 
-    [registrar addMethodCallDelegate:instance channel:instance.channel];
+    [registrar addMethodCallDelegate:OSFlutterNotifications.sharedInstance channel:OSFlutterNotifications.sharedInstance.channel];
     
     [OneSignal.Notifications setNotificationWillShowInForegroundHandler:^(OSNotification *notification, OSNotificationDisplayResponse completion) {
         [OSFlutterNotifications.sharedInstance handleNotificationWillShowInForeground:notification completion:completion];
@@ -122,15 +122,17 @@
 #pragma mark Received in Foreground Notification 
 
 - (void)initNotificationWillShowInForegroundHandlerParams {
+    NSLog(@"hasSetNotificationWillShowInForegroundHandler1");
     self.hasSetNotificationWillShowInForegroundHandler = YES;
 }
 
 - (void)handleNotificationWillShowInForeground:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion {
+    NSLog(@"Notification will show in foreground1");
     if (!self.hasSetNotificationWillShowInForegroundHandler) {
         completion(notification);
         return;
     }
-
+   NSLog(@"Notification will show in foreground2");
     self.receivedNotificationCache[notification.notificationId] = notification;
     self.notificationCompletionCache[notification.notificationId] = completion;
     [self.channel invokeMethod:@"OneSignal#handleNotificationWillShowInForeground" arguments:notification.toJson];
@@ -167,6 +169,7 @@
 }
 
 - (void)handleNotificationOpened:(OSNotificationOpenedResult *)result {
+     
     [self.channel invokeMethod:@"OneSignal#handleOpenedNotification" arguments:result.toJson];
 }
 

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -64,7 +64,7 @@
 #pragma mark FlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
-    [OneSignal setMSDKType:@"flutter"];
+    // [OneSignal setMSDKType:@"flutter"];
 
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel
                                      methodChannelWithName:@"OneSignal"

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -32,6 +32,7 @@
 #import "OSFlutterNotifications.h"
 #import "OSFlutterSession.h"
 #import "OSFlutterLocation.h"
+#import "OSFlutterInAppMessages.h"
 
 
 @interface OneSignalPlugin ()
@@ -64,7 +65,7 @@
 #pragma mark FlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
-    // [OneSignal setMSDKType:@"flutter"];
+    [OneSignal setMSDKType:@"flutter"];
 
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel
                                      methodChannelWithName:@"OneSignal"
@@ -76,6 +77,7 @@
     [OSFlutterNotifications registerWithRegistrar:registrar];
     [OSFlutterSession registerWithRegistrar:registrar];
     [OSFlutterLocation registerWithRegistrar:registrar];
+    [OSFlutterInAppMessages registerWithRegistrar:registrar];
     
 }
 

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -9,12 +9,14 @@ import 'package:onesignal_flutter/src/user.dart';
 import 'package:onesignal_flutter/src/notifications.dart';
 import 'package:onesignal_flutter/src/session.dart';
 import 'package:onesignal_flutter/src/location.dart';
+import 'package:onesignal_flutter/src/inappmessages.dart';
 
 export 'src/permission.dart';
 export 'src/defines.dart';
 export 'src/pushsubscription.dart';
 export 'src/subscription.dart';
 export 'src/notification.dart';
+export 'src/inappmessage.dart';
 
 class OneSignal {
   /// A singleton representing the OneSignal SDK.
@@ -27,6 +29,7 @@ class OneSignal {
   static OneSignalNotifications Notifications = new OneSignalNotifications();
   static OneSignalSession Session = new OneSignalSession();
   static OneSignalLocation Location = new OneSignalLocation();
+  static OneSignalInAppMessages InAppMessages = new OneSignalInAppMessages();
   
 
   // private channels used to bridge to ObjC/Java

--- a/lib/src/inappmessage.dart
+++ b/lib/src/inappmessage.dart
@@ -1,0 +1,50 @@
+import 'package:onesignal_flutter/src/utils.dart';
+
+/// When a click action is defined on an In App Message form the dashboard,
+/// the handler returns an OSInAppMessageAction object so the Dart code can act accordingly
+/// This allows for custom action events within Dart
+class OSInAppMessageAction extends JSONStringRepresentable {
+
+  // Name of the action event defined for the IAM element
+  String? clickName;
+
+  // URL given to the IAM element defined in the dashboard
+  String? clickUrl;
+
+  // Determines if a first click has occurred or not on the IAM element
+  bool firstClick = false;
+
+  // Whether or not the click action should dismiss the IAM
+  bool closesMessage = false;
+
+  OSInAppMessageAction(Map<String, dynamic> json) {
+    this.clickName = json["click_name"];
+    this.clickUrl = json["click_url"];
+    this.firstClick = json["first_click"] as bool;
+    this.closesMessage = json["closes_message"] as bool;
+  }
+
+  String jsonRepresentation() {
+    return convertToJsonString({
+      'click_name': this.clickName,
+      'click_url': this.clickUrl,
+      'first_click': this.firstClick,
+      'closes_message': this.closesMessage,
+    });
+  }
+
+}
+
+class OSInAppMessage extends JSONStringRepresentable {
+  String? messageId;
+
+  OSInAppMessage(Map<String, dynamic> json) {
+    this.messageId = json["message_id"];
+  } 
+
+  String jsonRepresentation() {
+    return convertToJsonString({
+      'message_id': this.messageId
+    });
+  }
+}

--- a/lib/src/inappmessages.dart
+++ b/lib/src/inappmessages.dart
@@ -58,8 +58,8 @@ class OneSignalInAppMessages {
   }
 
   /// Toggles the showing of all in app messages
-  Future<void> pause(bool pause) async {
-    return await _channel.invokeMethod("OneSignal#pause", pause);
+  Future<void> paused(bool pause) async {
+    return await _channel.invokeMethod("OneSignal#paused", pause);
   }
 
    /// Gets whether of not in app messages are paused

--- a/lib/src/inappmessages.dart
+++ b/lib/src/inappmessages.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'package:flutter/services.dart';
+import 'package:onesignal_flutter/src/defines.dart';
+import 'package:onesignal_flutter/src/inappmessage.dart';
+
+typedef void InAppMessageClickedHandler(OSInAppMessageAction action);
+typedef void OnWillDisplayInAppMessageHandler(OSInAppMessage message);
+typedef void OnDidDisplayInAppMessageHandler(OSInAppMessage message);
+typedef void OnWillDismissInAppMessageHandler(OSInAppMessage message);
+typedef void OnDidDismissInAppMessageHandler(OSInAppMessage message);
+
+class OneSignalInAppMessages {
+
+  // private channels used to bridge to ObjC/Java
+  MethodChannel _channel = const MethodChannel('OneSignal#inappmessages');
+
+
+  // constructor method
+  OneSignalInAppMessages() {
+    this._channel.setMethodCallHandler(_handleMethod);
+  }
+
+
+  InAppMessageClickedHandler? _onInAppMessageClickedHandler;
+  OnWillDisplayInAppMessageHandler? _onWillDisplayInAppMessageHandler;
+  OnDidDisplayInAppMessageHandler? _onDidDisplayInAppMessageHandler;
+  OnWillDismissInAppMessageHandler? _onWillDismissInAppMessageHandler;
+  OnDidDismissInAppMessageHandler? _onDidDismissInAppMessageHandler;
+
+   /// Adds a single key, value trigger, which will trigger an in app message
+  /// if one exists matching the specific trigger added
+  Future<void> addTrigger(String key, Object value) async {
+    return await _channel.invokeMethod("OneSignal#addTrigger", {key : value});
+  }
+
+  /// Adds one or more key, value triggers, which will trigger in app messages
+  /// (one at a time) if any exist matching the specific triggers added
+  Future<void> addTriggers(Map<String, Object> triggers) async {
+    return await _channel.invokeMethod("OneSignal#addTriggers", triggers);
+  }
+
+  /// Remove a single key, value trigger to prevent an in app message from
+  /// showing with that trigger
+  Future<void> removeTrigger(String key) async {
+    return await _channel.invokeMethod("OneSignal#removeTrigger", key);
+  }
+
+  /// Remove one or more key, value triggers to prevent any in app messages
+  /// from showing with those triggers
+  Future<void> removeTriggers(List<String> keys) async {
+    return await _channel.invokeMethod("OneSignal#removeTriggers", keys);
+  }
+
+  /// Get the trigger value associated with the key provided
+  Future<Object?> clearTriggers() async {
+    return await _channel.invokeMethod("OneSignal#clearTriggers");
+  }
+
+  /// Toggles the showing of all in app messages
+  Future<void> pause(bool pause) async {
+    return await _channel.invokeMethod("OneSignal#pause", pause);
+  }
+
+   /// Gets whether of not in app messages are paused
+  Future<void> arePaused() async {
+    return await _channel.invokeMethod("OneSignal#arePaused");
+  }
+  
+
+  // Private function that gets called by ObjC/Java
+  Future<Null> _handleMethod(MethodCall call) async {
+    if (call.method == 'OneSignal#handleClickedInAppMessage' &&
+        this._onInAppMessageClickedHandler != null) {
+      this._onInAppMessageClickedHandler!(
+          OSInAppMessageAction(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onWillDisplayInAppMessage' &&
+        this._onWillDisplayInAppMessageHandler != null) {
+      this._onWillDisplayInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onDidDisplayInAppMessage' &&
+        this._onDidDisplayInAppMessageHandler != null) {
+      this._onDidDisplayInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onWillDismissInAppMessage' &&
+        this._onWillDismissInAppMessageHandler != null) {
+      this._onWillDismissInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } else if (call.method == 'OneSignal#onDidDismissInAppMessage' &&
+        this._onDidDismissInAppMessageHandler != null) {
+      this._onDidDismissInAppMessageHandler!(
+          OSInAppMessage(call.arguments.cast<String, dynamic>()));
+    } 
+    return null;
+  }
+
+  /// The in app message clicked handler is called whenever the user clicks a
+  /// OneSignal IAM button or image with an action event attacthed to it
+  void setInAppMessageClickedHandler(InAppMessageClickedHandler handler) {
+    _onInAppMessageClickedHandler = handler;
+    _channel.invokeMethod("OneSignal#initInAppMessageClickedHandlerParams");
+  }
+
+  /// The in app message will display handler is called whenever the in app message
+  /// is about to be displayed
+  void setOnWillDisplayInAppMessageHandler(
+      OnWillDisplayInAppMessageHandler handler) {
+    _onWillDisplayInAppMessageHandler = handler;
+  }
+
+  /// The in app message did display handler is called whenever the in app message
+  /// is displayed
+  void setOnDidDisplayInAppMessageHandler(
+      OnDidDisplayInAppMessageHandler handler) {
+    _onDidDisplayInAppMessageHandler = handler;
+  }
+
+  /// The in app message will dismiss handler is called whenever the in app message
+  /// is about to be dismissed
+  void setOnWillDismissInAppMessageHandler(
+      OnWillDismissInAppMessageHandler handler) {
+    _onWillDismissInAppMessageHandler = handler;
+  }
+
+  /// The in app message did dismiss handler is called whenever the in app message
+  /// is dismissed
+  void setOnDidDismissInAppMessageHandler(
+      OnDidDismissInAppMessageHandler handler) {
+    _onDidDismissInAppMessageHandler = handler;
+  }
+
+}

--- a/lib/src/inappmessages.dart
+++ b/lib/src/inappmessages.dart
@@ -63,7 +63,7 @@ class OneSignalInAppMessages {
   }
 
    /// Gets whether of not in app messages are paused
-  Future<void> arePaused() async {
+  Future<bool> arePaused() async {
     return await _channel.invokeMethod("OneSignal#arePaused");
   }
   

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -87,9 +87,7 @@ class OneSignalNotifications {
   }
 
   Future<void> onOSPermissionChangedHandler(OSPermissionState state) async {
-    print("onOSPermissionChanged update in flutter");
     for (var observer in _observers) {
-       print("onOSPermissionChanged fired");
       observer.onOSPermissionChanged(state);
     }
   }


### PR DESCRIPTION
# Description
## One Line Summary

Adding the InAppMessages Namespace

## Details
### Handlers
```
   OneSignal.InAppMessages
        .setInAppMessageClickedHandler((OSInAppMessageAction action) {
        this.setState(() {
        _debugLabelString =
            "In App Message Clicked: \n${action.jsonRepresentation().replaceAll("\\n", "\n")}";
      });
    });

    OneSignal.InAppMessages.setOnWillDisplayInAppMessageHandler((message) {
      print("ON WILL DISPLAY IN APP MESSAGE ${message.messageId}");
    });

    OneSignal.InAppMessages.setOnDidDisplayInAppMessageHandler((message) {
      print("ON DID DISPLAY IN APP MESSAGE ${message.messageId}");
    });

    OneSignal.InAppMessages.setOnWillDismissInAppMessageHandler((message) {
      print("ON WILL DISMISS IN APP MESSAGE ${message.messageId}");
    });

    OneSignal.InAppMessages.setOnDidDismissInAppMessageHandler((message) {
      print("ON DID DISMISS IN APP MESSAGE ${message.messageId}");
    });
```
### Methods
```
    /// Example addTrigger call for IAM
    /// This will add 1 trigger so if there are any IAM satisfying it, it
    /// will be shown to the user
    OneSignal.InAppMessages.addTrigger("trigger_1", "one");

    /// Example addTriggers call for IAM
    /// This will add 2 triggers so if there are any IAM satisfying these, they
    /// will be shown to the user
    Map<String, Object> triggers = new Map<String, Object>();
    triggers["trigger_2"] = "two";
    triggers["trigger_3"] = "three";
    OneSignal.InAppMessages.addTriggers(triggers);

    // Removes a trigger by its key so if any future IAM are pulled with
    // these triggers they will not be shown until the trigger is added back
    OneSignal.InAppMessages.removeTrigger("trigger_2");


    // Create a list and bulk remove triggers based on keys supplied
    List<String> keys = ["trigger_1", "trigger_3"];
    OneSignal.InAppMessages.removeTriggers(keys);

    OneSignal.InAppMessages.clearTriggers();

    // Toggle pausing (displaying or not) of IAMs
    OneSignal.InAppMessages.paused(false);
    var arePaused = await OneSignal.InAppMessages.arePaused();
    print('Notifications paused ${arePaused}');
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/649)
<!-- Reviewable:end -->
