### PR TITLE
Release 3.5.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '3.5.0'
+version '3.5.1'
 
 buildscript {
     repositories {
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.onesignal:OneSignal:4.8.2'
+    api 'com.onesignal:OneSignal:4.8.5'
 }

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '3.5.0'
+  s.version          = '3.5.1'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '3.12.3'
+  s.dependency 'OneSignalXCFramework', '3.12.4'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 3.5.0
+version: 3.5.1
 author: Brad Hesse <brad@onesignal.com>, Josh Kasten <josh@onesignal.com>
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 


### PR DESCRIPTION
## Native iOS SDK Update
Bump native iOS SDK version from `3.12.3` to `3.12.4`
- Fix In App Messages occasionally being displayed twice 
- Fix a OneSignal log ignoring the "None" log level

## Native Android SDK Update
Bump native Android SDK version from `4.8.2` to `4.8.5`
- Fix issue which caused groupless notifications to not get cleared if there were at least 4 of them
- Remove OneSignal gradle plugin from build.gradle files 
- Fix an issue with liquid IAMs when a non-existent tag doesn't show the correct default value.
- Speculative Fix for WorkManager not Initialized Crash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/670)
<!-- Reviewable:end -->
