### PR TITLE
[User Model ]remove shared from OneSignal and make methods static

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,10 +35,10 @@ class _MyAppState extends State<MyApp> {
     OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
 
     OneSignal.Debug.setAlertLevel(OSLogLevel.none);
-    OneSignal.shared.consentRequired(_requireConsent);
+    OneSignal.consentRequired(_requireConsent);
 
     // NOTE: Replace with your own app ID from https://www.onesignal.com
-    OneSignal.shared.initialize("77e32082-ea27-42e3-a898-c72e141824ef");
+    OneSignal.initialize("0ba9731b-33bd-43f4-8b59-61172e27447d");
 
     // AndroidOnly stat only
     // OneSignal.Notifications.removeNotification(1);
@@ -103,7 +103,7 @@ class _MyAppState extends State<MyApp> {
     });
 
     // iOS-only method to open launch URLs in Safari when set to false
-    OneSignal.shared.setLaunchURLsInApp(false);
+    OneSignal.setLaunchURLsInApp(false);
 
     this.setState(() {
       _enableConsentButton = _requireConsent;
@@ -176,7 +176,7 @@ class _MyAppState extends State<MyApp> {
 
   void _handleConsent() {
     print("Setting consent to true");
-    OneSignal.shared.consentGiven(true);
+    OneSignal.consentGiven(true);
 
     print("Setting state");
     this.setState(() {
@@ -192,12 +192,12 @@ class _MyAppState extends State<MyApp> {
   void _handleLogin() {
     print("Setting external user ID");
     if (_externalUserId == null) return;
-    OneSignal.shared.login(_externalUserId!);
+    OneSignal.login(_externalUserId!);
     OneSignal.User.addAlias("fb_id", "1341524");
   }
 
   void _handleLogout() {
-    OneSignal.shared.logout();
+    OneSignal.logout();
     OneSignal.User.removeAlias("fb_id");
   }
 

--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -23,7 +23,6 @@ class OneSignal {
   /// Note that the iOS and Android native libraries are static,
   /// so if you create multiple instances of OneSignal, they will
   /// mostly share the same state.
-  static OneSignal shared = new OneSignal();
   static OneSignalDebug Debug = new OneSignalDebug();
   static OneSignalUser User = new OneSignalUser();
   static OneSignalNotifications Notifications = new OneSignalNotifications();
@@ -33,13 +32,13 @@ class OneSignal {
   static OneSignalLiveActivities LiveActivities = new OneSignalLiveActivities();
 
   // private channels used to bridge to ObjC/Java
-  MethodChannel _channel = const MethodChannel('OneSignal');
+  static MethodChannel _channel = const MethodChannel('OneSignal');
 
   /// The initializer for OneSignal.
   ///
   /// The initializer accepts an [appId] which the developer can get
   /// from the OneSignal consoleas well as a dictonary of [launchOptions]
-  void initialize(String appId) {
+  static void initialize(String appId) {
     _channel.invokeMethod('OneSignal#initialize', {'appId': appId});
     InAppMessages.lifecycleInit();
     User.pushSubscription.lifecycleInit();
@@ -50,7 +49,7 @@ class OneSignal {
   ///
   /// The act of logging a user into the OneSignal SDK will switch the
   /// user context to that specific user.
-  Future<void> login(String externalId) async {
+  static Future<void> login(String externalId) async {
     return await _channel
         .invokeMethod('OneSignal#login', {'externalId': externalId});
   }
@@ -59,7 +58,7 @@ class OneSignal {
   ///
   /// The act of logging a user into the OneSignal SDK will switch the
   /// user context to that specific user.
-  Future<void> loginWithJWT(String externalId, String jwt) async {
+  static Future<void> loginWithJWT(String externalId, String jwt) async {
     if (Platform.isAndroid) {
       return await _channel.invokeMethod(
           'OneSignal#loginWithJWT', {'externalId': externalId, 'jwt': jwt});
@@ -71,7 +70,7 @@ class OneSignal {
   /// references a new device-scoped user. A device-scoped user has no user identity
   /// that can later be retrieved, except through this device as long as the app
   /// remains installed and the app data is not cleared.
-  Future<void> logout() async {
+  static Future<void> logout() async {
     return await _channel.invokeMethod('OneSignal#logout');
   }
 
@@ -79,7 +78,7 @@ class OneSignal {
   ///
   /// This field is only relevant when the application has
   /// opted into data privacy protections. See [consentRequired].
-  Future<void> consentGiven(bool granted) async {
+  static Future<void> consentGiven(bool granted) async {
     return await _channel
         .invokeMethod("OneSignal#consentGiven", {'granted': granted});
   }
@@ -87,7 +86,7 @@ class OneSignal {
   /// Allows you to completely disable the SDK until your app calls the
   /// OneSignal.consentGiven(true) function. This is useful if you want
   /// to show a Terms and Conditions or privacy popup for GDPR.
-  Future<void> consentRequired(bool require) async {
+  static Future<void> consentRequired(bool require) async {
     return await _channel
         .invokeMethod("OneSignal#consentRequired", {'required': require});
   }
@@ -96,7 +95,7 @@ class OneSignal {
   /// within the application. Set to true to launch all notifications with a URL
   /// in the app instead of the default web browser. Make sure to call setLaunchURLsInApp
   /// before the initialize call.
-  Future<void> setLaunchURLsInApp(bool launchUrlsInApp) async {
+  static Future<void> setLaunchURLsInApp(bool launchUrlsInApp) async {
     if (Platform.isIOS) {
       return await _channel.invokeMethod(
           'OneSignal#setLaunchURLsInApp', {'launchUrlsInApp': launchUrlsInApp});


### PR DESCRIPTION

# Description
## One Line Summary
Everything on the shared instance of OneSignal should now be called on the static OneSignal namespace.

## Details

### Motivation
clean api

# Testing

## Manual testing
tested on iOS and android simulators

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/681)
<!-- Reviewable:end -->
