### PR TITLE
fix: typo with logout in ios method invoke channel

### DIFF
--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -77,7 +77,7 @@
         [self initialize:call withResult:result];
     else if ([@"OneSignal#login" isEqualToString:call.method])
         [self login:call withResult:result];
-    else if ([@"OneSignal#login" isEqualToString:call.method])
+    else if ([@"OneSignal#logout" isEqualToString:call.method])
         [self logout:call withResult:result];
     else if ([@"OneSignal#consentRequired" isEqualToString:call.method])
         [self setConsentRequired:call withResult:result];


### PR DESCRIPTION
# Description
## One Line Summary
Fixed typo when calling logout method in ios environment description that summaries the changes in this PR.

## Details

### Motivation
An error occurs when calling logout with the current version 5.0.0.

### Scope
Call logout method normally in ios environment

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/689)
<!-- Reviewable:end -->
