### PR TITLE
Add Proguard rules to fix --release bug

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-rules.pro'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,18 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in C:\Program Files (x86)\Android\sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+# Add any project specific keep options here:
+-keep class com.onesignal.** { *; }
+-dontwarn com.onesignal.**
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}


### PR DESCRIPTION
# Description
## One Line Summary
**REQUIRED** - Very short description that summaries the changes in this PR.

- Added Proguard rules to Android to prevent proguard/R8 minifying, on release builds of the apk.

## Details

### Motivation
**REQUIRED -** Why is this code change being made? Or what is the goal of this PR? Examples: Fixes a specific bug, provides additional logging to debug future issues, feature to allow X.

- On version 5.x of the Flutter SDK package, running with the --release flag or building a release apk will result in the obfuscation of some OneSignal logic that prevents methods from firing. These methods are crucial to OneSignal's ability to handle permissions (Android 13) and work with in app messaging.

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

- Limited to Android, this should not impact anything outside of release builds

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

- Tested building with 5.0 on a new project and after upgrading from a working version of 3.5.1 to 5.0. Tested this fix on 5.0.0-beta2 as well. All tests resulted in this error no longer showing in the logs, and the OneSignal methods working as expected. 

- I have tested all methods that were returning "implementation not found" in the error logs:
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MissingPluginException(No implementation found for method OneSignal#initialize on channel OneSignal) 

[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MissingPluginException(No implementation found for method OneSignal#lifecycleInit on channel OneSignal#inappmessages)

E/flutter (23235): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MissingPluginException(No implementation found for method OneSignal#pushSubscriptionToken on channel OneSignal#pushsubscription)

E/flutter (23235): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MissingPluginException(No implementation found for method OneSignal#permission on channel OneSignal#notifications)

E/flutter (23235): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MissingPluginException(No implementation found for method OneSignal#requestPermission on channel OneSignal#notifications)
```
- Not complex enough to warrant any automated testing, 

# Affected code checklist
(Setting below to open, as this was resulting in failed initialiization of the SDK on app open preventing methods from firing)
   - [x] Notifications
      - [x] Display
      - [✓] Open
      - [x] Push Processing
      - [x] Confirm Deliveries
   - [x] Outcomes
   - [x] Sessions
   - [x] In-App Messaging
   - [x] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [✓] I have filled out all **REQUIRED** sections above
   - [✓] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [✓] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [✓] I have included test coverage for these changes, or explained why they are not needed
   - [✓] All automated tests pass, or I explained why that is not possible
   - [✓] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [✓] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [✓] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/716)
<!-- Reviewable:end -->
