### PR TITLE
Fix permission not updating until start of session

### DIFF
--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -119,6 +119,9 @@ class OneSignalNotifications {
 
   Future<void> lifecycleInit() async {
     _permission = await _channel.invokeMethod("OneSignal#permission");
+    addPermissionObserver((permission) {
+      _permission = permission;
+    });
     return await _channel.invokeMethod("OneSignal#lifecycleInit");
   }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fixes the `OneSignal.Notification.permission` value not updating until the start of the next session.

## Details
Fixes #734 
The permission field was not marked as async so we cannot use `await _channel.invokeMethod("OneSignal#permission");`
Instead I have added ourselves as a permission observer that will update the _permission boolean whenever the observer fires.

### Motivation
bug fix

### Scope
notification permissions

# Testing

## Manual testing
Tested on iOS device

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.