### PR TITLE
Fix notification clicked listener firing from cold start

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -68,6 +68,8 @@ public class OneSignalNotifications extends FlutterRegistrarResponder implements
         this.lifecycleInit();
     else if (call.method.contentEquals("OneSignal#proceedWithWillDisplay"))
         this.proceedWithWillDisplay(call, result);
+    else if (call.method.contentEquals("OneSignal#addNativeClickListener"))
+        this.registerClickListener();
     else
         replyNotImplemented(result);
     }
@@ -184,7 +186,10 @@ public class OneSignalNotifications extends FlutterRegistrarResponder implements
 
     private void lifecycleInit() {
         OneSignal.getNotifications().addForegroundLifecycleListener(this);
-        OneSignal.getNotifications().addClickListener(this);
         OneSignal.getNotifications().addPermissionObserver(this);
+    }
+
+    private void registerClickListener() {
+        OneSignal.getNotifications().addClickListener(this);
     }
 } 

--- a/ios/Classes/OSFlutterNotifications.m
+++ b/ios/Classes/OSFlutterNotifications.m
@@ -73,6 +73,8 @@
         [self lifecycleInit:call withResult:result];
     else if ([@"OneSignal#proceedWithWillDisplay" isEqualToString:call.method])
         [self proceedWithWillDisplay:call withResult:result];
+    else if ([@"OneSignal#addNativeClickListener" isEqualToString:call.method])
+        [self registerClickListener:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -103,8 +105,12 @@
 
 - (void)lifecycleInit:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     [OneSignal.Notifications addForegroundLifecycleListener:self];
-    [OneSignal.Notifications addClickListener:self];
     [OneSignal.Notifications addPermissionObserver:self];
+    result(nil);
+}
+
+- (void)registerClickListener:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [OneSignal.Notifications addClickListener:self];
     result(nil);
 }
 

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -55,6 +55,7 @@
 #pragma mark FlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
+    [OneSignal initialize:nil withLaunchOptions:nil];
     OneSignalWrapper.sdkType = @"flutter";
     OneSignalWrapper.sdkVersion = @"050001";
     

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.0.1'
+  s.dependency 'OneSignalXCFramework', '5.0.2'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -31,6 +31,8 @@ class OneSignalNotifications {
 
   bool _permission = false;
 
+  bool _clickHandlerRegistered = false;
+
   /// Whether this app has push notification permission.
   bool get permission {
     return _permission;
@@ -177,6 +179,10 @@ class OneSignalNotifications {
   /// The notification click listener is called whenever the user opens a
   /// OneSignal push notification, or taps an action button on a notification.
   void addClickListener(OnNotificationClickListener listener) {
+    if (!_clickHandlerRegistered) {
+      _clickHandlerRegistered = true;
+      _channel.invokeMethod("OneSignal#addNativeClickListener");
+    }
     _clickListeners.add(listener);
   }
 


### PR DESCRIPTION
# Description
## One Line Summary
This PR allows the click listener to be fired when the app is closed.

## Details

- Bumps the iOS dependency to 5.0.2
- Don't register the bridge click listener until a dart click listener is added.
- Initialize OneSignal native when the plugin is registered


# Testing
## Unit testing
none

## Manual testing
Tested on Android and iOS devices with multiple push notifications from a cold start, background, and foreground.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/752)
<!-- Reviewable:end -->
