### PR TITLE
Add canRequest to Android

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -52,6 +52,8 @@ public class OneSignalNotifications extends FlutterRegistrarResponder implements
     public void onMethodCall(MethodCall call, Result result) {
     if (call.method.contentEquals("OneSignal#permission"))
         replySuccess(result, OneSignal.getNotifications().getPermission());
+    else if (call.method.contentEquals("OneSignal#canRequest"))
+        replySuccess(result, OneSignal.getNotifications().getCanRequestPermission());
     else if (call.method.contentEquals("OneSignal#requestPermission"))
         this.requestPermission(call, result);
     else if (call.method.contentEquals("OneSignal#removeNotification"))

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -59,11 +59,7 @@ class OneSignalNotifications {
   /// Whether attempting to request notification permission will show a prompt.
   /// Returns true if the device has not been prompted for push notification permission already.
   Future<bool> canRequest() async {
-    if (Platform.isIOS) {
-      return await _channel.invokeMethod("OneSignal#canRequest");
-    } else {
-      return false;
-    }
+    return await _channel.invokeMethod("OneSignal#canRequest");
   }
 
   /// Removes a single notification.


### PR DESCRIPTION
# Description
## One Line Summary
`OneSignal.Notifications.canRequest()` has been fixed for Android in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1798, make it available in Flutter SDK.

## Details

### Motivation
Add `OneSignal.Notifications.canRequest()` functionality to Android. It was previously iOS-only, with Android always returning `false`.

### Scope
Adds `OneSignal.Notifications.canRequest()` functionality to Android. 

Note that the method `OneSignal.Notifications.canRequest()` returns whether or not the device has been prompted for push already, and may not indicate on Android whether or not a push prompt will display.

# Testing

## Manual testing
Testing on Android emulator API 33:

1. New app install and see `canRequest = true`
2. Prompt for push and accept
3. See `canRequest = false` which is correct

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/753)
<!-- Reviewable:end -->
