### PR TITLE
Fix clearTriggers on Android

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
@@ -44,6 +44,8 @@ IInAppMessageClickListener, IInAppMessageLifecycleListener{
             this.removeTrigger(call, result);
         else if (call.method.contentEquals("OneSignal#removeTriggers"))
             this.removeTriggers(call, result);
+        else if (call.method.contentEquals("OneSignal#clearTriggers"))
+            this.clearTriggers(call, result);
         else if (call.method.contentEquals("OneSignal#arePaused"))
             replySuccess(result, OneSignal.getInAppMessages().getPaused());
         else if (call.method.contentEquals("OneSignal#paused"))
@@ -79,6 +81,11 @@ IInAppMessageClickListener, IInAppMessageLifecycleListener{
         } catch (ClassCastException e) {
             replyError(result, "OneSignal", "Remove triggers for keys failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }
+    }
+
+    private void clearTriggers(MethodCall call, Result result) {
+        OneSignal.getInAppMessages().clearTriggers();
+        replySuccess(result, null);
     }
 
     private void paused(MethodCall call, Result result) {


### PR DESCRIPTION
# Description
## One Line Summary
The Android native bridge will now properly handle clearTriggers.

## Details
fixes #767 
`OneSignalInAppMessages.java` was not listening to clearTriggers so an error would throw when calling clearTriggers on 
an Android device.

### Motivation
Fix clearTriggers

### Scope
IAM triggers

# Testing

## Manual testing
tested on pixel 7

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/771)
<!-- Reviewable:end -->
