### PR TITLE
Fix #764

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace("com.onesignal.flutter") 
+    }
     compileSdkVersion 28
 
     defaultConfig {


### PR DESCRIPTION
# Description
## One Line Summary
This PR provide the package namespace if the AGP is equal or higher than 8.

## Details

### Motivation
By adding the namespace condition for AGP 8 and higher, this fix the issue [Bug]: AGP 8 not supported https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/764

### Scope
Affected Android builds

# Testing
## Unit testing

## Manual testing
Tested during the Gradle sync with AGP 8+

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/792)
<!-- Reviewable:end -->
