### PR TITLE
Fix Android User calls to always resolve

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -58,6 +58,7 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
             language = null;
         }
         OneSignal.getUser().setLanguage(language);
+        replySuccess(result, null);
     }
 
     private void addAliases(MethodCall call, Result result) {
@@ -65,6 +66,7 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
         //  a ClassCastException will be thrown
         try {
             OneSignal.getUser().addAliases((Map<String, String>) call.arguments);
+            replySuccess(result, null);
         } catch(ClassCastException e) {
             replyError(result, "OneSignal", "addAliases failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }
@@ -75,6 +77,7 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
         //  a ClassCastException will be thrown
         try {
             OneSignal.getUser().removeAliases((List<String>) call.arguments);
+            replySuccess(result, null);
         } catch(ClassCastException e) {
             replyError(result, "OneSignal", "removeAliases failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }
@@ -105,6 +108,7 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
         //  a ClassCastException will be thrown
         try {
             OneSignal.getUser().addTags((Map<String, String>) call.arguments);
+            replySuccess(result, null);
         } catch(ClassCastException e) {
             replyError(result, "OneSignal", "addTags failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }
@@ -115,6 +119,7 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
         //  a ClassCastException will be thrown
         try {
             OneSignal.getUser().removeTags((List<String>) call.arguments);
+            replySuccess(result, null);
         } catch(ClassCastException e) {
             replyError(result, "OneSignal", "deleteTags failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -54,10 +54,10 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
 
     private void setLanguage(MethodCall call, Result result) {
         String language = call.argument("language");
-        if (language != null && language.length() == 0)
-          language = null;
-    
-          OneSignal.getUser().setLanguage(language);
+        if (language != null && language.length() == 0) {
+            language = null;
+        }
+        OneSignal.getUser().setLanguage(language);
     }
 
     private void addAliases(MethodCall call, Result result) {
@@ -83,23 +83,24 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
     private void addEmail(MethodCall call, Result result) {
         OneSignal.getUser().addEmail((String) call.arguments);
         replySuccess(result, null);
-      }
+    }
     
-      private void removeEmail(MethodCall call, Result result) {
+    private void removeEmail(MethodCall call, Result result) {
         OneSignal.getUser().removeEmail((String) call.arguments);
         replySuccess(result, null);
-      }
+    }
     
-      private void addSms(MethodCall call, Result result) {
+    private void addSms(MethodCall call, Result result) {
         OneSignal.getUser().addSms((String) call.arguments);
         replySuccess(result, null);
-      }
+    }
     
-      private void removeSms(MethodCall call, Result result) {
+    private void removeSms(MethodCall call, Result result) {
         OneSignal.getUser().removeSms((String) call.arguments);
         replySuccess(result, null);
-      }
-      private void addTags(MethodCall call, Result result) {
+    }
+
+    private void addTags(MethodCall call, Result result) {
         // call.arguments is being casted to a Map<String, Object> so a try-catch with
         //  a ClassCastException will be thrown
         try {
@@ -118,6 +119,4 @@ public class OneSignalUser extends FlutterRegistrarResponder implements MethodCa
             replyError(result, "OneSignal", "deleteTags failed with error: " + e.getMessage() + "\n" + e.getStackTrace(), null);
         }
     }
-    
-     
 }


### PR DESCRIPTION
# Description
## One Line Summary
Resolve all Android user namespace methods over the bridge as some were missed.

## Details

### Motivation
Fixes https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/799 
Fixes https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/789

### Scope
Resolve all User namespace methods over the Android bridge, some of them were missed like `addTag` or `removeTag`. This was only for people using `await` with these methods and waiting on the response, doesn't change any implementation details.

# Testing
## Unit testing
None

## Manual testing
Android Nexus S Emulator API 33, tested with calling `addTag` with `await` and seeing that it resolves after these changes.

```
await OneSignal.User.addTagWithKey("test2", "val2");
```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/800)
<!-- Reviewable:end -->
