### PR TITLE
[fix] Android: Resolve `requestPermission` call when already granted

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -78,6 +78,12 @@ public class OneSignalNotifications extends FlutterRegistrarResponder implements
 
     private void requestPermission(MethodCall call, Result result) {
         boolean fallback = (boolean) call.argument("fallbackToSettings");
+        // if permission already exists, return early as the method call will not resolve
+        if (OneSignal.getNotifications().getPermission()) {
+            replySuccess(result, true);
+            return;
+        }
+
         OneSignal.getNotifications().requestPermission(fallback, Continue.with(permissionResult -> {
             replySuccess(result, permissionResult.getData());
         }));


### PR DESCRIPTION
# Description
## One Line Summary
Resolve `requestPermission` call if permission is already granted.

## Details
**Problem:**
If permission is already enabled, the native call to `OneSignal.getNotifications().requestPermission(fallbackToSettings, Continue.with(...)` never suspends and the Continuation code block never runs. As a result, we would not be able to resolve the promise over the bridge.

**Solution:**
Before calling that method, do a permission check and return **true**. 
I chose to check the permission in Android bridge instead of resolving early in Dart because the Dart-level `_permission` boolean may not be set yet when `requestPermission` is called soon after initialization. I ran into this case when testing the following scenario:

Test scenario
```dart
// Notification permission has already been granted

OneSignal.initialize("YOUR_APP_ID");
print('BEFORE calling requestPermission');
bool perm = await OneSignal.Notifications.requestPermission(true);

// The following did not print prior to this PR
print('AFTER calling requestPermission with answer: $perm');
```

### Motivation
Resolve calls to request permission correctly so app code doesn't hang.
A customer reached out to support.

### Scope
Now, we also resolve correctly when permission has already been granted.

# Testing
## Unit testing
None

## Manual testing
Android emulator API 33

- Tested the boolean returned when permission is accepted and denied and it returns true and false respectively.
- Tested combinations of toggling permissions in app settings and calls to requestPermission.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/806)
<!-- Reviewable:end -->
