### PR TITLE
[chore] Android: move namespace declaration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
 
-     if (project.android.hasProperty("namespace")) {
+    if (project.android.hasProperty("namespace")) {
         namespace 'com.onesignal.onesignalexample'  
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 android {
 
     if (project.android.hasProperty("namespace")) {
-        namespace 'com.onesignal.onesignalexample'  
+        namespace 'com.onesignal.flutter'  
     }
 
     compileSdkVersion 28

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+
+     if (project.android.hasProperty("namespace")) {
+        namespace 'com.onesignal.onesignalexample'  
+    }
+
     compileSdkVersion 28
 
     defaultConfig {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 17 14:56:12 PDT 2019
+#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.onesignal.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,6 +15,11 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+
+     if (project.android.hasProperty("namespace")) {
+        namespace 'com.onesignal.onesignalexample'  
+    }
+
     compileSdkVersion 33
 
     lintOptions {
@@ -24,7 +29,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.onesignal.onesignalexample"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -16,8 +16,8 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
 
-     if (project.android.hasProperty("namespace")) {
-        namespace 'com.onesignal.onesignalexample'  
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.onesignal.onesignalexample'
     }
 
     compileSdkVersion 33

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.onesignal.onesignalexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
-    }
+        classpath 'com.android.tools.build:gradle:8.0.1' 
+           }
 }
 
 allprojects {
@@ -17,6 +17,8 @@ allprojects {
 }
 
 rootProject.buildDir = '../build'
+
+
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }
@@ -24,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.1' 
-           }
+    }
 }
 
 allprojects {

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 17 15:00:44 PDT 2019
+#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip


### PR DESCRIPTION
# Description
## One Line Summary
Enables building apps with agp =< 8.0

## Details

### Motivation
As [this](https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/792) helpful PR already attempted, for apps using Gradle 8.0 or greater, moving the namespace declaration from the `AndroidManifest.xml` files is necessary.
The other PR has a minor syntax error and doesnt delete the conflicting declaration in the xml files.

Otherwise developers will be confronted with this error: 
```
* What went wrong:
A problem occurred evaluating root project 'android'.
> A problem occurred configuring project ':app'.
   > Could not create an instance of type com.android.build.api.variant.impl.ApplicationVariantImpl.
      > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

        android {
            namespace 'com.example.namespace'
        }

        If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```
Or other, more obscure warnings thrown by the gradle wrapper.

### Scope
None of the actual source is changed, the changes are contained to the android directory of the package and the example app.

### Other
I've also updated the AndroidManifest.xml files to have their namespace declaration, e.g. `package="com.onesignal.onesignalexample"` in the `<manifest>` tag removed, as the AGP upgrade agent would also refactor to be in line with the newer gradle versions.

## Manual testing
Tested building the example and my own app, using flutter sdks 3.16.5 and 3.13.0, respectively. All features in the example app work as intended. They also shouldn't be affected by my changes.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

None apply, buildscripts are affected.
# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/818)
<!-- Reviewable:end -->
