### PR TITLE
[user model] Added the namespace property in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,10 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    // Condition for namespace compatibility in AGP 8
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.onesignal.flutter'
+    }
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    // Condition for namespace compatibility in AGP 8
+    // Condition for namespace compatibility in AGP <4.2
     if (project.android.hasProperty("namespace")) {
         namespace 'com.onesignal.flutter'
     }


### PR DESCRIPTION
# Description
## One Line Summary
This PR provide the package namespace if the AGP is equal or higher then 8. 

## Details
This PR is a cherry-pick of this main branch PR https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/765 for the user_model branch.

### Motivation
By adding the namespace condition for AGP 8 and higher, this fix the issue [Bug]: AGP 8 not supported #764 

# Testing

## Manual testing
Tested during the Gradle sync with AGP 9

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/825)
<!-- Reviewable:end -->
