### PR TITLE
Fix Live Activities methods were not working due to bridge error

### DIFF
--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -33,6 +33,7 @@
 #import "OSFlutterSession.h"
 #import "OSFlutterLocation.h"
 #import "OSFlutterInAppMessages.h"
+#import "OSFlutterLiveActivities.h"
 
 
 @interface OneSignalPlugin ()
@@ -70,7 +71,7 @@
     [OSFlutterSession registerWithRegistrar:registrar];
     [OSFlutterLocation registerWithRegistrar:registrar];
     [OSFlutterInAppMessages registerWithRegistrar:registrar];
-    
+    [OSFlutterLiveActivities registerWithRegistrar:registrar];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {


### PR DESCRIPTION
# Description
## One Line Summary
Fix the Live Activities `enter` and `exit` methods were not working by registering the Live Activities class with Flutter.

## Details

### Motivation
Fix error
```
Unhandled Exception: MissingPluginException(No implementation found for method 
OneSignal#enterLiveActivity on channel OneSignal#liveactivities)
```

### Scope
Bug fix that didn't register the `OSFlutterLiveActivities` class.

# Testing
## Unit testing

## Manual testing
- Physical iphone 13 with ios 17.2
- Call `OneSignal.LiveActivities.enterLiveActivity("activityId", "token")` and `OneSignal.LiveActivities.exitLiveActivity("activityId")`
- Before PR: encounter that error
- After PR: See the native enter and exit requests get logged and receive successful network response

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Live Activities

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/860)
<!-- Reviewable:end -->
