### PR TITLE
Release 5.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.1.6'
+version '5.2.0'
 
 buildscript {
     repositories {
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.1.10'
+    implementation 'com.onesignal:OneSignal:5.1.13'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -40,7 +40,7 @@ public class OneSignalPlugin extends FlutterRegistrarResponder implements Flutte
     this.messenger = messenger;
     OneSignalWrapper.setSdkType("flutter");  
     // For 5.0.0, hard code to reflect SDK version
-    OneSignalWrapper.setSdkVersion("050106");
+    OneSignalWrapper.setSdkVersion("050200");
     
     channel = new MethodChannel(messenger, "OneSignal");
     channel.setMethodCallHandler(this);

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -58,7 +58,7 @@
 
     [OneSignal initialize:nil withLaunchOptions:nil];
     OneSignalWrapper.sdkType = @"flutter";
-    OneSignalWrapper.sdkVersion = @"050106";
+    OneSignalWrapper.sdkVersion = @"050200";
     
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel
                                      methodChannelWithName:@"OneSignal"

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.1.6'
+  s.version          = '5.2.0'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.1.6
+version: 5.2.0
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 flutter:


### PR DESCRIPTION
What's New
--------
### 🎉 Push to Start Live Activities
Starting with iOS 17.2, Live Activities can now be started via push notification ([Apple's documentation](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Start-new-Live-Activities-with-ActivityKit-push-notifications)). This change enhances the OneSignal SDK to provide application's access to the full suite of Live Activity functionality.

To use Push To Start Live Activities, see documentation on [How to start a Live Activity with a remote push notification](https://documentation.onesignal.com/docs/push-to-start-live-activities).

**Default Live Activity**
The concept of a "Default" Live Activity has been established in the SDK, which eliminates the need for a customer app to define and manage their own `ActivityAttributes`. The primary use case of the "Default" Live Activity is to facilitate easier cross-platform adoption.

- A new function `OneSignal.LiveActivities.setupDefault()` which tells the OneSignal SDK to manage the LiveActivity lifecycle for the `DefaultLiveActivityAttributes` type. When calling this method, a customer can use both `push-to-start` and `push-to-update` notifications to start/update/end their Default Live Activity.
- A new function `OneSignal.LiveActivities.startDefault(activityId, activityAttributes, initialContentState)` which allows a customer app to start a live activity based on the `DefaultLiveActivityAttributes` type "in app".

**Four New APIs for Live Activities**
```dart
OneSignal.LiveActivities.setupDefault()
OneSignal.LiveActivities.startDefault(activityId, activityAttributes, initialContentState)
OneSignal.LiveActivities.setPushToStartToken(String activityType, String token)
OneSignal.LiveActivities.removePushToStartToken(String activityType)
```

Please see the PR description for more details.
- Push to start live activities added to the SDK (#881)

🔧 Native SDK Dependency Updates
--------
### Update Android SDK from `5.1.10` to `5.1.13`
- For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
**🐛 Bug Fixes**
- [Fix] grouping skipping opRepoPostCreateDelay, causing operations being applied out of order when multiple login operations are pending. (fixes issue since 5.1.10) ([2087](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2087))
- [Fix]: Cancelling permission request dialog does not fire continuation ([2085](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2085))
- [Fix] RecoverFromDroppedLoginBug not running in very rare cases ([2084](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2084))
- Fix the ANR issue caused by prolonged loading of OperationRepo and potentially by extended holding of the model lock during disk I/O read operations. ([2068](ttps://github.com/OneSignal/OneSignal-Android-SDK/pull/2068))
**🔧 Maintenance**
- Add HTTP header `OneSignal-Install-Id` that allows the OneSignal's backend know where traffic is coming from ([2072](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2072))

### Update iOS SDK from `5.1.6` to `5.2.0`
- [5.2.0 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.0)
- ✨ Privacy Manifest Improvements
- 🐛 [Bug] Fix rare scenario of dropping data when multiple logins are called ([1427](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1427))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/889)
<!-- Reviewable:end -->
