### PR TITLE
Release 5.2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.2.0'
+version '5.2.1'
 
 buildscript {
     repositories {
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.1.13'
+    implementation 'com.onesignal:OneSignal:5.1.15'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -40,7 +40,7 @@ public class OneSignalPlugin extends FlutterRegistrarResponder implements Flutte
     this.messenger = messenger;
     OneSignalWrapper.setSdkType("flutter");  
     // For 5.0.0, hard code to reflect SDK version
-    OneSignalWrapper.setSdkVersion("050200");
+    OneSignalWrapper.setSdkVersion("050201");
     
     channel = new MethodChannel(messenger, "OneSignal");
     channel.setMethodCallHandler(this);

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -58,7 +58,7 @@
 
     [OneSignal initialize:nil withLaunchOptions:nil];
     OneSignalWrapper.sdkType = @"flutter";
-    OneSignalWrapper.sdkVersion = @"050200";
+    OneSignalWrapper.sdkVersion = @"050201";
     
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel
                                      methodChannelWithName:@"OneSignal"

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.2.0'
+  s.dependency 'OneSignalXCFramework', '5.2.1'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.2.0'
+  s.version          = '5.2.1'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.2.0
+version: 5.2.1
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 flutter:


### PR DESCRIPTION
🔧 Native SDK Dependency Updates
--------
### Update Android SDK from `5.1.13` to `5.1.15`
For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)

### 🐛 Bug Fixes
- Xiaomi notification click was not foregrounding app https://github.com/OneSignal/OneSignal-Android-SDK/pull/2129
- FCM push token was not being refreshed (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2125, https://github.com/OneSignal/OneSignal-Android-SDK/pull/2118)
- Poll for notification permission changes to detect permission change when prompting outside of OneSignal https://github.com/OneSignal/OneSignal-Android-SDK/pull/2112
- WorkManager fixes when the app uses a custom WorkManager https://github.com/OneSignal/OneSignal-Android-SDK/pull/2122

### ✨ Improvements
- Cold start creates new session and refreshes the user from the server https://github.com/OneSignal/OneSignal-Android-SDK/pull/2113

### Update iOS SDK from `5.2.0` to `5.2.1`
[5.2.0 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.1)

### 🐛 Bug Fixes
- Fix warning about decoding a boolean (#1436)
- Fix a purchases bug for the amount spent (#1444)
- Fix a build issue for mac catalyst (#1446)
- Fix crash when IAM window fails to load by using the main thread (#1447)

### 🔧 Maintenance 
- **Network call optimizations:** Combine user property updates for network call improvements (#1444)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/906)
<!-- Reviewable:end -->
