### PR TITLE
Set wrapper sdk type before calling initialize

### DIFF
--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -56,10 +56,10 @@
 #pragma mark FlutterPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
-    [OneSignal initialize:nil withLaunchOptions:nil];
     OneSignalWrapper.sdkType = @"flutter";
     OneSignalWrapper.sdkVersion = @"050202";
-    
+    [OneSignal initialize:nil withLaunchOptions:nil];
+
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel
                                      methodChannelWithName:@"OneSignal"
                                      binaryMessenger:[registrar messenger]];


### PR DESCRIPTION
# Description
## One Line Summary
On the native iOS SDK, set the wrapper SDK type first before calling initialize.

## Details

### Motivation
* Set the wrapper SDK type first so when initialize is called, the native SDK can check if the SDK is a wrapper type in order to conditionally omit a misleading fatal log
* See https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1468

### Scope
* Safe to re-order, as other wrapper SDKs already do

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/932)
<!-- Reviewable:end -->
