### PR TITLE
Release 5.2.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.2.6'
+version '5.2.7'
 
 buildscript {
     repositories {
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.1.23'
+    implementation 'com.onesignal:OneSignal:5.1.24'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -40,7 +40,7 @@ public class OneSignalPlugin extends FlutterRegistrarResponder implements Flutte
     this.messenger = messenger;
     OneSignalWrapper.setSdkType("flutter");  
     // For 5.0.0, hard code to reflect SDK version
-    OneSignalWrapper.setSdkVersion("050206");
+    OneSignalWrapper.setSdkVersion("050207");
     
     channel = new MethodChannel(messenger, "OneSignal");
     channel.setMethodCallHandler(this);

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -57,7 +57,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
     OneSignalWrapper.sdkType = @"flutter";
-    OneSignalWrapper.sdkVersion = @"050206";
+    OneSignalWrapper.sdkVersion = @"050207";
     [OneSignal initialize:nil withLaunchOptions:nil];
 
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.2.6'
+  s.version          = '5.2.7'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.2.5'
+  s.dependency 'OneSignalXCFramework', '5.2.7'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.2.6
+version: 5.2.7
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 flutter:


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------
### Update Android SDK from 5.1.23 to 5.1.24 | [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.24)

🐛 Bug Fixes
* Fix setting consentGiven throwing if called before initWithContext [#2200](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2200)
* Window manager BadTokenException / WindowLeaked [#2208](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2208)

✨ Improvements
* Make use of ryw_delay to minimize retries on IAM fetch [#2207](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2207)

### Update iOS SDK from 5.2.5 to 5.2.7 | [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.7)
✨ Improvements
- Don't use cached in-app messages if the SDK encounters an error fetching them or when the server returns none [#1499](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1499)
- Improve segment membership calculation that allows for fetching more accurate and updated in-app messages for a user [#1486](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1486)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/969)
<!-- Reviewable:end -->
