### PR TITLE
Release 5.2.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.2.7'
+version '5.2.8'
 
 buildscript {
     repositories {
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.1.24'
+    implementation 'com.onesignal:OneSignal:5.1.25'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -40,7 +40,7 @@ public class OneSignalPlugin extends FlutterRegistrarResponder implements Flutte
     this.messenger = messenger;
     OneSignalWrapper.setSdkType("flutter");  
     // For 5.0.0, hard code to reflect SDK version
-    OneSignalWrapper.setSdkVersion("050207");
+    OneSignalWrapper.setSdkVersion("050208");
     
     channel = new MethodChannel(messenger, "OneSignal");
     channel.setMethodCallHandler(this);

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -57,7 +57,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
     OneSignalWrapper.sdkType = @"flutter";
-    OneSignalWrapper.sdkVersion = @"050207";
+    OneSignalWrapper.sdkVersion = @"050208";
     [OneSignal initialize:nil withLaunchOptions:nil];
 
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.2.7'
+  s.version          = '5.2.8'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.2.7'
+  s.dependency 'OneSignalXCFramework', '5.2.8'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.2.7
+version: 5.2.8
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 flutter:


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------
### Update Android SDK from 5.1.24 to 5.1.25 | [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.25)

🐛 Bug Fixes

- [Fix] NPE by getScheduleBackgroundRunIn [OneSignal/OneSignal-Android-SDK#2212](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2212)

### Update iOS SDK from 5.2.7 to 5.2.8 | [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.8)
🐛 Bug Fixes

- Fix [__NSPlaceholderDictionary initWithObjects:forKeys:count:] crashes caused by nil HTTPResponse headers [OneSignal/OneSignal-iOS-SDK#1518](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1518)

✨ Improvements

- Include debug symbols (dSYM) in the SDK [OneSignal/OneSignal-iOS-SDK#1519](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1519)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/976)
<!-- Reviewable:end -->
