### PR TITLE
Switch docs for setShared and isShared

### DIFF
--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -10,13 +10,13 @@ class OneSignalLocation {
     return await _channel.invokeMethod("OneSignal#requestPermission");
   }
 
-  /// Allows you to determine if the user's location data is shared with OneSignal.
-  /// This allows you to do things like geofenced notifications, etc.
+  /// Set whether location is currently shared with OneSignal.
   Future<void> setShared(bool shared) async {
     return await _channel.invokeMethod("OneSignal#setShared", shared);
   }
 
-  /// Set whether location is currently shared with OneSignal.
+  /// Allows you to determine if the user's location data is shared with OneSignal.
+  /// This allows you to do things like geofenced notifications, etc.
   Future<bool> isShared() async {
     return await _channel.invokeMethod("OneSignal#isShared");
   }


### PR DESCRIPTION


# Description
## One Line Summary
**REQUIRED** - The descriptions for the two methods setShared and isShared (under the Location module) appear to have been switched. This change switches them back to how they probably should be.

## Details

### Motivation
**REQUIRED -** Having docs that are correct is nice!

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - x ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/995)
<!-- Reviewable:end -->
