### PR TITLE
[breaking] Remove deprecated Android v1 embedding references

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/FlutterMessengerResponder.java
+++ b/android/src/main/java/com/onesignal/flutter/FlutterMessengerResponder.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
 
-abstract class FlutterRegistrarResponder {
+abstract class FlutterMessengerResponder {
    Context context;
    protected MethodChannel channel;
    BinaryMessenger messenger;

--- a/android/src/main/java/com/onesignal/flutter/FlutterMessengerResponder.java
+++ b/android/src/main/java/com/onesignal/flutter/FlutterMessengerResponder.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
-import com.onesignal.OneSignal;
-
 import java.util.HashMap;
 
 import io.flutter.plugin.common.BinaryMessenger;

--- a/android/src/main/java/com/onesignal/flutter/FlutterRegistrarResponder.java
+++ b/android/src/main/java/com/onesignal/flutter/FlutterRegistrarResponder.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry;
 
 abstract class FlutterRegistrarResponder {
    Context context;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalDebug.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalDebug.java
@@ -3,13 +3,6 @@ package com.onesignal.flutter;
 import com.onesignal.OneSignal;
 import com.onesignal.debug.LogLevel;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalDebug.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalDebug.java
@@ -15,8 +15,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalDebug extends FlutterRegistrarResponder implements MethodCallHandler {
     

--- a/android/src/main/java/com/onesignal/flutter/OneSignalDebug.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalDebug.java
@@ -16,7 +16,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalDebug extends FlutterRegistrarResponder implements MethodCallHandler {
+public class OneSignalDebug extends FlutterMessengerResponder implements MethodCallHandler {
     
    static void registerWith(BinaryMessenger messenger) {
         OneSignalDebug controller = new OneSignalDebug();

--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
@@ -21,7 +21,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalInAppMessages extends FlutterRegistrarResponder implements MethodCallHandler, 
 IInAppMessageClickListener, IInAppMessageLifecycleListener{

--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
@@ -22,7 +22,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalInAppMessages extends FlutterRegistrarResponder implements MethodCallHandler, 
+public class OneSignalInAppMessages extends FlutterMessengerResponder implements MethodCallHandler, 
 IInAppMessageClickListener, IInAppMessageLifecycleListener{
 
     static void registerWith(BinaryMessenger messenger) {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
@@ -3,11 +3,9 @@ package com.onesignal.flutter;
 import com.onesignal.OneSignal;
 import com.onesignal.debug.internal.logging.Logging;
 import org.json.JSONException;
-import org.json.JSONObject;
-import com.onesignal.inAppMessages.IInAppMessage;
+
 import com.onesignal.inAppMessages.IInAppMessageClickListener;
 import com.onesignal.inAppMessages.IInAppMessageClickEvent;
-import com.onesignal.inAppMessages.IInAppMessageClickResult;
 import com.onesignal.inAppMessages.IInAppMessageLifecycleListener;
 import com.onesignal.inAppMessages.IInAppMessageWillDisplayEvent;
 import com.onesignal.inAppMessages.IInAppMessageDidDisplayEvent;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
@@ -3,13 +3,6 @@ package com.onesignal.flutter;
 import com.onesignal.OneSignal;
 import com.onesignal.Continue;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
@@ -15,8 +15,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalLocation extends FlutterRegistrarResponder implements MethodCallHandler {
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
@@ -16,7 +16,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalLocation extends FlutterRegistrarResponder implements MethodCallHandler {
+public class OneSignalLocation extends FlutterMessengerResponder implements MethodCallHandler {
 
     static void registerWith(BinaryMessenger messenger) {
         OneSignalLocation controller = new OneSignalLocation();

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -8,25 +8,15 @@ import com.onesignal.Continue;
 import com.onesignal.notifications.INotification;
 import com.onesignal.notifications.INotificationClickEvent;
 import com.onesignal.notifications.INotificationWillDisplayEvent;
-import com.onesignal.notifications.INotificationClickResult;
-import com.onesignal.notifications.INotificationReceivedEvent;
 import com.onesignal.notifications.INotificationClickListener;
 import com.onesignal.notifications.INotificationLifecycleListener;
 import com.onesignal.notifications.IPermissionObserver;
-
-import com.onesignal.user.subscriptions.ISubscription;
-import com.onesignal.user.subscriptions.IPushSubscription;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -34,7 +34,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalNotifications extends FlutterRegistrarResponder implements MethodCallHandler, INotificationClickListener, INotificationLifecycleListener, IPermissionObserver {
+public class OneSignalNotifications extends FlutterMessengerResponder implements MethodCallHandler, INotificationClickListener, INotificationLifecycleListener, IPermissionObserver {
     private final HashMap<String, INotificationWillDisplayEvent> notificationOnWillDisplayEventCache = new HashMap<>();
     private final HashMap<String, INotificationWillDisplayEvent> preventedDefaultCache = new HashMap<>();
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -33,8 +33,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalNotifications extends FlutterRegistrarResponder implements MethodCallHandler, INotificationClickListener, INotificationLifecycleListener, IPermissionObserver {
     private final HashMap<String, INotificationWillDisplayEvent> notificationOnWillDisplayEventCache = new HashMap<>();

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -1,21 +1,12 @@
 package com.onesignal.flutter;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 
 import com.onesignal.OneSignal;
-import com.onesignal.Continue;
 import com.onesignal.common.OneSignalWrapper;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,9 +24,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
-import io.flutter.view.FlutterNativeView;
 
 /** OnesignalPlugin */
 public class OneSignalPlugin extends FlutterRegistrarResponder implements FlutterPlugin, MethodCallHandler, ActivityAware {
@@ -85,24 +82,6 @@ public class OneSignalPlugin extends FlutterRegistrarResponder implements Flutte
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {
-  }
-
-  // This static method is only to remain compatible with apps that don’t use the v2 Android embedding.
-  @Deprecated()
-  @SuppressLint("Registrar")
-  public static void registerWith(Registrar registrar) {
-    final OneSignalPlugin plugin = new OneSignalPlugin();
-    plugin.init(registrar.activeContext(), registrar.messenger());
-
-    // Create a callback for the flutterRegistrar to connect the applications onDestroy
-    registrar.addViewDestroyListener(new PluginRegistry.ViewDestroyListener() {
-      @Override
-      public boolean onViewDestroy(FlutterNativeView flutterNativeView) {
-        // Remove all handlers so they aren't triggered with wrong context
-        plugin.onDetachedFromEngine();
-        return false;
-      }
-    });
   }
 
   @Override

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -26,7 +26,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
 /** OnesignalPlugin */
-public class OneSignalPlugin extends FlutterRegistrarResponder implements FlutterPlugin, MethodCallHandler, ActivityAware {
+public class OneSignalPlugin extends FlutterMessengerResponder implements FlutterPlugin, MethodCallHandler, ActivityAware {
 
   public OneSignalPlugin() {
   }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
@@ -21,8 +21,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalPushSubscription extends FlutterRegistrarResponder implements MethodCallHandler, IPushSubscriptionObserver {
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
@@ -22,7 +22,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalPushSubscription extends FlutterRegistrarResponder implements MethodCallHandler, IPushSubscriptionObserver {
+public class OneSignalPushSubscription extends FlutterMessengerResponder implements MethodCallHandler, IPushSubscriptionObserver {
 
     static void registerWith(BinaryMessenger messenger) {
         OneSignalPushSubscription controller = new OneSignalPushSubscription();

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
@@ -2,19 +2,11 @@ package com.onesignal.flutter;
 
 import com.onesignal.OneSignal;
 
-import com.onesignal.user.subscriptions.IPushSubscription;
-import com.onesignal.user.subscriptions.ISubscription;
 import com.onesignal.user.subscriptions.IPushSubscriptionObserver;
 import com.onesignal.user.subscriptions.PushSubscriptionChangedState;
-import com.onesignal.user.subscriptions.PushSubscriptionState;
 import com.onesignal.debug.internal.logging.Logging;
 
 import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSerializer.java
@@ -1,11 +1,7 @@
 package com.onesignal.flutter;
 
-import android.util.Log;
-
 import com.onesignal.user.state.UserChangedState;
 import com.onesignal.user.state.UserState;
-import com.onesignal.user.subscriptions.ISubscription;
-import com.onesignal.user.subscriptions.IPushSubscription;
 import com.onesignal.user.subscriptions.PushSubscriptionChangedState;
 import com.onesignal.user.subscriptions.PushSubscriptionState;
 import com.onesignal.inAppMessages.IInAppMessage;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
@@ -10,8 +10,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalSession extends FlutterRegistrarResponder implements MethodCallHandler {
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
@@ -2,9 +2,6 @@ package com.onesignal.flutter;
 
 import com.onesignal.OneSignal;
 
-import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
@@ -11,7 +11,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalSession extends FlutterRegistrarResponder implements MethodCallHandler {
+public class OneSignalSession extends FlutterMessengerResponder implements MethodCallHandler {
 
     static void registerWith(BinaryMessenger messenger) {
         OneSignalSession controller = new OneSignalSession();

--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -18,8 +18,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class OneSignalUser extends FlutterRegistrarResponder implements MethodCallHandler, IUserStateObserver {
 

--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -1,17 +1,14 @@
 package com.onesignal.flutter;
 
 import com.onesignal.OneSignal;
-import com.onesignal.debug.LogLevel;
 import com.onesignal.debug.internal.logging.Logging;
 import com.onesignal.user.state.IUserStateObserver;
 import com.onesignal.user.state.UserChangedState;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;

--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -19,7 +19,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-public class OneSignalUser extends FlutterRegistrarResponder implements MethodCallHandler, IUserStateObserver {
+public class OneSignalUser extends FlutterMessengerResponder implements MethodCallHandler, IUserStateObserver {
 
     static void registerWith(BinaryMessenger messenger) {
         OneSignalUser controller = new OneSignalUser();


### PR DESCRIPTION
# Description
## One Line Summary
Drop support for Android v1 embedding, which is quite old.

## Details
The main changes are in one commit: [60dcfc](https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/1005/commits/60dcfc407537270c1992584cccd252d287557e7a) while others are nits.

* Remove references to the now deprecated v1 Android embedding. 
* The SDK used classes `PluginRegistry.Registrar` and `io.flutter.view.FlutterNativeView` 
* However, to support newer Flutter versions, we now need to completely drop v1 support.
* Investigated other PRs in open-source repositories

### Motivation
Reported in https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/928

Users targeting Flutter master and beta/stable releases after (but not including) `3.27` will fail to compile if the plugin has references any v1 embedding classes.

### Scope

- Drop support for Android v1
- How many Flutter apps are actively maintained today that still use v1? Unsure but I can't imagine many at all.
- From the issue reported above:

> The v1 embedding was deprecated around 6 and a half years ago. In Flutter `3.22`, the Flutter tool dropped support for building v1 apps entirely.

# Testing
## Unit testing

## Manual testing
1. Created new sample app on Flutter `3.29.0` and reproduced the reported build error.
2. Change the dependency to the changes in this PR.
3. App builds and runs, logs print, SDK works.
4. Note that our embedded example app is on v2 and has been since PR https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/486


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Deprecation changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1005)
<!-- Reviewable:end -->
