### PR TITLE
fix: export user.dart to expose `OSUserChangedState`

### DIFF
--- a/lib/onesignal_flutter.dart
+++ b/lib/onesignal_flutter.dart
@@ -17,6 +17,7 @@ export 'src/notifications.dart';
 export 'src/inappmessage.dart';
 export 'src/inappmessages.dart';
 export 'src/liveactivities.dart';
+export 'src/user.dart';
 
 class OneSignal {
   /// A singleton representing the OneSignal SDK.


### PR DESCRIPTION
# Description
## One Line Summary
Export `user.dart` to expose `OSUserChangedState`.

## Details

### Motivation
- Fixes https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/1049
- Checked other files that are not exported, and they don't need to be. They have no other types to expose.

### Scope
Export user.dart

# Testing
## Unit testing
NA

## Manual testing
Reproduced by adding typing of `OSUserChangedState` to our example app, which errors before changes in this PR.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes - only exposing a type meant to be public

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1054)
<!-- Reviewable:end -->
