### PR TITLE
test: make handler methods private

### DIFF
--- a/lib/src/inappmessages.dart
+++ b/lib/src/inappmessages.dart
@@ -21,7 +21,7 @@ class OneSignalInAppMessages {
 
   // constructor method
   OneSignalInAppMessages() {
-    this._channel.setMethodCallHandler(handleMethod);
+    this._channel.setMethodCallHandler(_handleMethod);
   }
 
   List<OnClickInAppMessageListener> _clickListeners =
@@ -79,8 +79,7 @@ class OneSignalInAppMessages {
   }
 
   // Private function that gets called by ObjC/Java
-  // Exposed as public for testing purposes
-  Future<Null> handleMethod(MethodCall call) async {
+  Future<Null> _handleMethod(MethodCall call) async {
     if (call.method == 'OneSignal#onClickInAppMessage') {
       for (var listener in _clickListeners) {
         listener(

--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -26,7 +26,7 @@ class OneSignalNotifications {
       <OnNotificationPermissionChangeObserver>[];
   // constructor method
   OneSignalNotifications() {
-    this._channel.setMethodCallHandler(handleMethod);
+    this._channel.setMethodCallHandler(_handleMethod);
   }
 
   bool _permission = false;
@@ -123,7 +123,7 @@ class OneSignalNotifications {
     return await _channel.invokeMethod("OneSignal#lifecycleInit");
   }
 
-  Future<Null> handleMethod(MethodCall call) async {
+  Future<Null> _handleMethod(MethodCall call) async {
     if (call.method == 'OneSignal#onClickNotification') {
       for (var listener in _clickListeners) {
         listener(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,5 +27,5 @@ dev_dependencies:
   rps: ^0.9.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
+  flutter: ">=2.0.0"

--- a/test/inappmessages_test.dart
+++ b/test/inappmessages_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onesignal_flutter/src/inappmessage.dart';
 import 'package:onesignal_flutter/src/inappmessages.dart';
@@ -146,14 +145,12 @@ void main() {
 
         inAppMessages.addClickListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onClickInAppMessage',
-            {
-              'message': validMessageJson,
-              'result': validClickResultJson,
-            },
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onClickInAppMessage',
+          {
+            'message': validMessageJson,
+            'result': validClickResultJson,
+          },
         );
 
         expect(listenerCalled, true);
@@ -169,14 +166,12 @@ void main() {
         inAppMessages.addClickListener(listener);
         inAppMessages.removeClickListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onClickInAppMessage',
-            {
-              'message': validMessageJson,
-              'result': validClickResultJson,
-            },
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onClickInAppMessage',
+          {
+            'message': validMessageJson,
+            'result': validClickResultJson,
+          },
         );
 
         expect(listenerCalled, false);
@@ -195,11 +190,9 @@ void main() {
 
         inAppMessages.addWillDisplayListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onWillDisplayInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onWillDisplayInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, true);
@@ -216,11 +209,9 @@ void main() {
         inAppMessages.addWillDisplayListener(listener);
         inAppMessages.removeWillDisplayListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onWillDisplayInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onWillDisplayInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, false);
@@ -237,11 +228,9 @@ void main() {
 
         inAppMessages.addDidDisplayListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onDidDisplayInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onDidDisplayInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, true);
@@ -257,11 +246,9 @@ void main() {
         inAppMessages.addDidDisplayListener(listener);
         inAppMessages.removeDidDisplayListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onDidDisplayInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onDidDisplayInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, false);
@@ -276,11 +263,9 @@ void main() {
 
         inAppMessages.addDidDisplayListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onDidDisplayInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onDidDisplayInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, true);
@@ -299,11 +284,9 @@ void main() {
 
         inAppMessages.addWillDismissListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onWillDismissInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onWillDismissInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, true);
@@ -320,11 +303,9 @@ void main() {
         inAppMessages.addWillDismissListener(listener);
         inAppMessages.removeWillDismissListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onWillDismissInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onWillDismissInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, false);
@@ -343,11 +324,9 @@ void main() {
 
         inAppMessages.addDidDismissListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onDidDismissInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onDidDismissInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, true);
@@ -364,11 +343,9 @@ void main() {
         inAppMessages.addDidDismissListener(listener);
         inAppMessages.removeDidDismissListener(listener);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onDidDismissInAppMessage',
-            {'message': validMessageJson},
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onDidDismissInAppMessage',
+          {'message': validMessageJson},
         );
 
         expect(listenerCalled, false);
@@ -390,14 +367,12 @@ void main() {
         inAppMessages.addClickListener(listener1);
         inAppMessages.addClickListener(listener2);
 
-        await inAppMessages.handleMethod(
-          MethodCall(
-            'OneSignal#onClickInAppMessage',
-            {
-              'message': validMessageJson,
-              'result': validClickResultJson,
-            },
-          ),
+        channelController.simulateInAppMessageEvent(
+          'OneSignal#onClickInAppMessage',
+          {
+            'message': validMessageJson,
+            'result': validClickResultJson,
+          },
         );
 
         expect(listenerCount, 2);

--- a/test/mock_channel.dart
+++ b/test/mock_channel.dart
@@ -79,6 +79,66 @@ class OneSignalMockChannelController {
     );
   }
 
+  // Generic helper method to simulate method calls from native on any channel
+  void simulateMethodCall(
+      String channelName, String methodName, dynamic arguments) {
+    final MethodChannel channel;
+
+    switch (channelName) {
+      case 'OneSignal':
+        channel = _channel;
+        break;
+      case 'OneSignal#debug':
+        channel = _debugChannel;
+        break;
+      case 'OneSignal#tags':
+        channel = _tagsChannel;
+        break;
+      case 'OneSignal#location':
+        channel = _locationChannel;
+        break;
+      case 'OneSignal#inappmessages':
+        channel = _inAppMessagesChannel;
+        break;
+      case 'OneSignal#liveactivities':
+        channel = _liveActivitiesChannel;
+        break;
+      case 'OneSignal#notifications':
+        channel = _notificationsChannel;
+        break;
+      case 'OneSignal#pushsubscription':
+        channel = _pushSubscriptionChannel;
+        break;
+      case 'OneSignal#session':
+        channel = _sessionChannel;
+        break;
+      case 'OneSignal#user':
+        channel = _userChannel;
+        break;
+      default:
+        throw ArgumentError('Unknown channel: $channelName');
+    }
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      channel.name,
+      channel.codec.encodeMethodCall(
+        MethodCall(methodName, arguments),
+      ),
+      (ByteData? data) {},
+    );
+  }
+
+  // Convenience wrapper for in-app message events
+  void simulateInAppMessageEvent(String eventName, Map<String, dynamic> data) {
+    simulateMethodCall('OneSignal#inappmessages', eventName, data);
+  }
+
+  // Convenience wrapper for notification events
+  void simulateNotificationEvent(String eventName, Map<String, dynamic> data) {
+    simulateMethodCall('OneSignal#notifications', eventName, data);
+  }
+
   Future<dynamic> _handleMethod(MethodCall call) async {
     switch (call.method) {
       case "OneSignal#initialize":

--- a/test/notifications_test.dart
+++ b/test/notifications_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onesignal_flutter/src/defines.dart';
 import 'package:onesignal_flutter/src/notification.dart';
@@ -289,8 +288,8 @@ void main() {
         }
 
         notifications.addForegroundWillDisplayListener(listener);
-        await notifications.handleMethod(MethodCall(
-            'OneSignal#onWillDisplayNotification', notificationData));
+        channelController.simulateNotificationEvent(
+            'OneSignal#onWillDisplayNotification', notificationData);
 
         expect(listenerCalled, true);
       });
@@ -303,8 +302,8 @@ void main() {
 
         notifications.addForegroundWillDisplayListener(listener);
         notifications.removeForegroundWillDisplayListener(listener);
-        await notifications.handleMethod(MethodCall(
-            'OneSignal#onWillDisplayNotification', notificationData));
+        channelController.simulateNotificationEvent(
+            'OneSignal#onWillDisplayNotification', notificationData);
 
         expect(listenerCalled, false);
       });
@@ -323,8 +322,8 @@ void main() {
         notifications.addForegroundWillDisplayListener(listener1);
         notifications.addForegroundWillDisplayListener(listener2);
 
-        await notifications.handleMethod(MethodCall(
-            'OneSignal#onWillDisplayNotification', notificationData));
+        channelController.simulateNotificationEvent(
+            'OneSignal#onWillDisplayNotification', notificationData);
 
         expect(listener1Called, true);
         expect(listener2Called, true);
@@ -345,8 +344,8 @@ void main() {
         notifications.addForegroundWillDisplayListener(listener2);
         notifications.removeForegroundWillDisplayListener(listener1);
 
-        await notifications.handleMethod(MethodCall(
-            'OneSignal#onWillDisplayNotification', notificationData));
+        channelController.simulateNotificationEvent(
+            'OneSignal#onWillDisplayNotification', notificationData);
 
         expect(listener1Called, false);
         expect(listener2Called, true);


### PR DESCRIPTION
# Description
## One Line Summary
Makes the `handleMethod` functions in `inappmessages.dart` and `notifications.dart` private again

## Details
- makes handlemethod method private again and update tests to simulate events via binarymessenger sender

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1080)
<!-- Reviewable:end -->
