### PR TITLE
ci: update release with secret and target repo

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -3,6 +3,10 @@ name: Create Release PR
 on:
   # For making a release pr from android / ios sdk actions
   workflow_call:
+    secrets:
+      GH_PUSH_TOKEN:
+        required: false
+        description: "GitHub token for pushing changes"
     inputs:
       flutter_version:
         description: "New Flutter SDK Version (e.g., 5.3.4 or 5.3.4-beta.1)"
@@ -22,7 +26,7 @@ on:
         type: string
         default: main
 
-  # For making a release pr from cordova github actions
+  # For making a release pr from the github actions
   workflow_dispatch:
     inputs:
       flutter_version:
@@ -46,14 +50,19 @@ on:
 jobs:
   prep:
     uses: OneSignal/sdk-actions/.github/workflows/prep-release.yml@main
+    secrets:
+      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      target_repo: OneSignal/OneSignal-Flutter-SDK
       version: ${{ inputs.flutter_version }}
 
-  update-version:
+  update_version:
     needs: prep
     runs-on: macos-latest
     outputs:
-      flutter_from: ${{ steps.current_versions.outputs.cordova_from }}
+      flutter_from: ${{ steps.current_versions.outputs.flutter_from }}
       android_from: ${{ steps.current_versions.outputs.android_from }}
       ios_from: ${{ steps.current_versions.outputs.ios_from }}
 
@@ -61,7 +70,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+          repository: OneSignal/OneSignal-Flutter-SDK
           ref: ${{ needs.prep.outputs.release_branch }}
+          token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
 
       - name: Get current native SDK versions
         id: current_versions
@@ -152,9 +164,14 @@ jobs:
           git push
 
   create-pr:
-    needs: [prep, update-version]
+    needs: [prep, update_version]
     uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
+    secrets:
+      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      target_repo: OneSignal/OneSignal-Flutter-SDK
       release_branch: ${{ needs.prep.outputs.release_branch }}
       target_branch: ${{ inputs.target_branch }}
       android_from: ${{ needs.update-version.outputs.android_from }}


### PR DESCRIPTION
# Description
## One Line Summary
- update create release pr to use target_repo & gh_push_token

## Details
- needs target_repo to be passed in for `prep-release` otherwise the sdk-actions or whichever caller would set the github.repostiry to itself e.g. creating create release branch in sdk-actions instead of the flutter repo
- needs GH_PUSH_TOKEN otherwise the caller e.g. (sdk-acitons) would 403 / error when trying to create a release-branch or other changes
- updates checkout step to specify the repsitory and token
- updates create-pr to accept push token secret and the target-repo

Example of sdk-acitons w/o target_repo:
https://github.com/OneSignal/sdk-actions/actions/runs/19555353422/job/55996469655 (create release pr in sdk-acitons not the wrappers)

Example of sdk-actions w/o token:
https://github.com/OneSignal/sdk-actions/actions/runs/19556567680/job/56000216159 (403 error when trying to push to release branch)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1081)
<!-- Reviewable:end -->
