### PR TITLE
chore: Release 5.3.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.1.35'
+    implementation 'com.onesignal:OneSignal:5.4.0'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -28,7 +28,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder implements Flutte
     this.messenger = messenger;
     OneSignalWrapper.setSdkType("flutter");  
     // For 5.0.0, hard code to reflect SDK version
-    OneSignalWrapper.setSdkVersion("050304");
+    OneSignalWrapper.setSdkVersion("050305");
     
     channel = new MethodChannel(messenger, "OneSignal");
     channel.setMethodCallHandler(this);

--- a/ios/Classes/OneSignalPlugin.m
+++ b/ios/Classes/OneSignalPlugin.m
@@ -57,7 +57,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
 
     OneSignalWrapper.sdkType = @"flutter";
-    OneSignalWrapper.sdkVersion = @"050304";
+    OneSignalWrapper.sdkVersion = @"050305";
     [OneSignal initialize:nil withLaunchOptions:nil];
 
     OneSignalPlugin.sharedInstance.channel = [FlutterMethodChannel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.3.4
+version: 5.3.5
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 scripts:


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes

- fix: export user.dart to expose `OSUserChangedState` (#1054)


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.1.35 to 5.4.0
  - 5.2.x - Identity Verification (JWT) - Feature is still in beta
  - 5.3.x - Custom Outcomes - Feature is still in beta
  - improvement: Offloaded work on background threads. ([#2394](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2394))
  - improvement: Using a OneSignal Threadpool to execute all OneSignal related operations
  - improvement: Added newer suspend methods that could be used in ViewModels to init the SDK, login and logout
  - improvement: Improved code quality around PermissionsActivity.
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - ANR GmsLocationController timing out ([#2396]https://github.com/OneSignal/OneSignal-Android-SDK/issues/2396)
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2335
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2266
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2397
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2399
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2400
  - Crash/ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2192
  - - -
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - - -
  - feat: Add Kotlin MainApplication and suspend initialization support ([#2374](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2374))
  - - -
  - **Non-blocking initialization**
  - OneSignal.initWithContext has been refactored so heavy disk and network work are moved off the main thread. ANRs related to initialization should now be effectively eliminated when the SDK is used in the recommended way (see Notes below).
  - **Performance Improvements**
  - In our testing, the time spent on the main thread during initialization dropped by ~80% (e.g., from ~47–49 ms down to ~8 ms on a cold start in debug builds).
  - If your app calls OneSignal accessors (ex. OneSignal.User.oneSignalID) immediately after initWithContext, we recommend moving all OneSignal accessor calls off the main thread.
  - No breaking API changes; existing initWithContext(context) continues to work as before.
  - JWT: Resolve IAM conditions after user create to allow fetching of IAMs in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2337
  - rebased with 5.1.35 which include the following:
  - #2327
  - #2329
  - #2328
  - #2330
  - #2332
  - #2333
  - This limitation will be addressed in the next version
  - Switched publishing to use the Central Publisher Portal
  - _No changes to those using the SDK in their project_
  - Rebased to 5.1.34 for more bug fixes and stability improvements.
  - Adds the following new public methods #2311:
  - `OneSignal.Debug.addLogListener`
  - `OneSignal.Debug.removeLogListener`
  - Rebased to 5.1.33 for more bug fixes and stability improvement.
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - - -
  - fix(subs): Fix when multiple create subscription operations exist without token ([OneSignal-Android-SDK#2354](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2354))
  - fix (crash): Finishing the activity on main thread when a notification is opened ([OneSignal-Android-SDK#2353](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2353))
  - fix(crash): NPE in PermissionsActivity (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2349)
  - fix(subs): Fix parsing subscriptions from server, and improve handling of deleted push subscriptions (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2341)
  - docs: Fix formatting issues in migration guide (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2347)
  - docs: Update migration guide to point to remote docs (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2346)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1088)
<!-- Reviewable:end -->
