### PR TITLE
fix: complete lifecycleInit Future on Android

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
@@ -48,7 +48,7 @@ IInAppMessageClickListener, IInAppMessageLifecycleListener{
         else if (call.method.contentEquals("OneSignal#paused"))
             this.paused(call, result);
         else if (call.method.contentEquals("OneSignal#lifecycleInit"))
-            this.lifecycleInit();
+            this.lifecycleInit(result);
         else
             replyNotImplemented(result);
     }
@@ -90,9 +90,10 @@ IInAppMessageClickListener, IInAppMessageLifecycleListener{
         replySuccess(result, null);
     }
 
-    public void lifecycleInit() {
+    public void lifecycleInit(Result result) {
         OneSignal.getInAppMessages().addLifecycleListener(this);
         OneSignal.getInAppMessages().addClickListener(this);
+        replySuccess(result, null);
     }
 
     @Override

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -87,7 +87,7 @@ public class OneSignalNotifications extends FlutterMessengerResponder implements
     else if (call.method.contentEquals("OneSignal#preventDefault"))
         this.preventDefault(call, result);
     else if (call.method.contentEquals("OneSignal#lifecycleInit"))
-        this.lifecycleInit();
+        this.lifecycleInit(result);
     else if (call.method.contentEquals("OneSignal#proceedWithWillDisplay"))
         this.proceedWithWillDisplay(call, result);
     else if (call.method.contentEquals("OneSignal#addNativeClickListener"))
@@ -210,9 +210,10 @@ public class OneSignalNotifications extends FlutterMessengerResponder implements
         invokeMethodOnUiThread("OneSignal#onNotificationPermissionDidChange", hash);
     }
 
-    private void lifecycleInit() {
+    private void lifecycleInit(Result result) {
         OneSignal.getNotifications().addForegroundLifecycleListener(this);
         OneSignal.getNotifications().addPermissionObserver(this);
+        replySuccess(result, null);
     }
 
     private void registerClickListener() {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
@@ -36,7 +36,7 @@ public class OneSignalPushSubscription extends FlutterMessengerResponder impleme
         else if (call.method.contentEquals("OneSignal#pushSubscriptionOptedIn"))
             replySuccess(result, OneSignal.getUser().getPushSubscription().getOptedIn());
         else if (call.method.contentEquals("OneSignal#lifecycleInit"))
-            this.lifecycleInit();
+            this.lifecycleInit(result);
         else
             replyNotImplemented(result);
     }
@@ -50,8 +50,9 @@ public class OneSignalPushSubscription extends FlutterMessengerResponder impleme
         replySuccess(reply, null);
     }
 
-    private void lifecycleInit() {
+    private void lifecycleInit(Result result) {
         OneSignal.getUser().getPushSubscription().addObserver(this);
+        replySuccess(result, null);
     }  
 
     @Override

--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -53,7 +53,7 @@ public class OneSignalUser extends FlutterMessengerResponder
         else if (call.method.contentEquals("OneSignal#getTags"))
             this.getTags(call, result);
         else if (call.method.contentEquals("OneSignal#lifecycleInit"))
-            this.lifecycleInit();
+            this.lifecycleInit(result);
         else
             replyNotImplemented(result);
     }
@@ -67,8 +67,9 @@ public class OneSignalUser extends FlutterMessengerResponder
         replySuccess(result, null);
     }
 
-    private void lifecycleInit() {
+    private void lifecycleInit(Result result) {
         OneSignal.getUser().addObserver(this);
+        replySuccess(result, null);
     }
 
     private void getOnesignalId(MethodCall call, Result result) {


### PR DESCRIPTION
# Description
## One Line Summary
Fix Android `lifecycleInit()` `Future` not completing, causing await to hang indefinitely.

## Details

### Motivation
- Addresses https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/937
- The lifecycleInit() methods in Android were not completing their Futures, which can cause await calls to hang indefinitely. This fix adds the Result parameter and calls replySuccess() to properly complete the Future, matching the iOS implementation.

### Scope
Not a public method but update for consistency and future proofing

# Testing

## Manual testing
Android emulator on API 35

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1095)
<!-- Reviewable:end -->
