### PR TITLE
feat: add removeAllClickListeners method to avoid keeping instances of all click listeners

### DIFF
--- a/lib/src/notifications.dart
+++ b/lib/src/notifications.dart
@@ -185,4 +185,8 @@ class OneSignalNotifications {
   void removeClickListener(OnNotificationClickListener listener) {
     _clickListeners.remove(listener);
   }
+
+  void removeAllClickListeners() {
+    _clickListeners.clear();
+  }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Add removeAllClickListeners method to avoid keeping instances of all click listeners
## Details

### Motivation
It is quite cumbersome to keep instances of all click listeners. Most of the time we have one, but need a simple way to remove it. By clearing all, it does the job just fine. Also, in state management, it prevents recreating click listeners when initializing method are fired multiple times.

### Scope
Notification click listeners

## Manual testing
Tested on my apps without any problem

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1118)
<!-- Reviewable:end -->
