### PR TITLE
chore: rename sdk-actions to sdk-shared

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
 
   create-release:
     needs: publish
-    uses: OneSignal/sdk-actions/.github/workflows/github-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/github-release.yml@main
     secrets:
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: flutter analyze
 
       - name: Setup Clang
-        uses: OneSignal/sdk-actions/.github/actions/setup-clang@main
+        uses: OneSignal/sdk-shared/.github/actions/setup-clang@main
 
       - name: Check formatting (dart,java,c)
         run: dart run rps format-check

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -49,12 +49,12 @@ on:
 
 jobs:
   prep:
-    uses: OneSignal/sdk-actions/.github/workflows/prep-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/prep-release.yml@main
     secrets:
-      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      # Need this cross-repo token (sdk-shared & this repo) to perform changes
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
-      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/OneSignal-Flutter-SDK
       version: ${{ inputs.flutter_version }}
 
@@ -70,13 +70,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
           repository: OneSignal/OneSignal-Flutter-SDK
           ref: ${{ needs.prep.outputs.release_branch }}
           token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
 
       - name: Setup Git User
-        uses: OneSignal/sdk-actions/.github/actions/setup-git-user@main
+        uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
 
       - name: Get current native SDK versions from target branch
         id: current_versions
@@ -176,12 +176,12 @@ jobs:
 
   create-pr:
     needs: [prep, update_version]
-    uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/create-release.yml@main
     secrets:
-      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      # Need this cross-repo token (sdk-shared & this repo) to perform changes
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
-      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/OneSignal-Flutter-SDK
       release_branch: ${{ needs.prep.outputs.release_branch }}
       target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call:
-    uses: OneSignal/sdk-actions/.github/workflows/lint-pr-title.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/lint-pr-title.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
Update all GitHub workflow references from `sdk-actions` to `sdk-shared` to reflect the repo rename.

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Flutter-SDK/1120)
<!-- Reviewable:end -->
