### PR TITLE
chore: Release 5.5.0

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -159,7 +159,7 @@ jobs:
           echo "✓ Updated pubspec.yaml version to ${NEW_VERSION}"
 
           # Update podspec version
-          sed -i '' "s|s.version          = '[^']*'|s.version          = '${NEW_VERSION}'|" ios/onesignal_flutter.podspec
+          sed -i '' "s|s\.version[[:space:]]*=[[:space:]]*'[^']*'|s.version          = '${NEW_VERSION}'|" ios/onesignal_flutter.podspec
           echo "✓ Updated ios/onesignal_flutter.podspec version to ${NEW_VERSION}"
 
           # Update android build.gradle version

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -158,6 +158,14 @@ jobs:
           sed -i '' "s/^version:.*/version: $NEW_VERSION/" pubspec.yaml
           echo "✓ Updated pubspec.yaml version to ${NEW_VERSION}"
 
+          # Update podspec version
+          sed -i '' "s|s.version          = '[^']*'|s.version          = '${NEW_VERSION}'|" ios/onesignal_flutter.podspec
+          echo "✓ Updated ios/onesignal_flutter.podspec version to ${NEW_VERSION}"
+
+          # Update android build.gradle version
+          sed -i '' "s|^version '[^']*'|version '${NEW_VERSION}'|" android/build.gradle
+          echo "✓ Updated android/build.gradle version to ${NEW_VERSION}"
+
           # Update OneSignalPlugin.java wrapper version
           sed -i '' "s/OneSignalWrapper\.setSdkVersion(\"[^\"]*\")/OneSignalWrapper.setSdkVersion(\"$WRAPPER_VERSION\")/g" android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.3.4'
+version '5.5.0'
 
 buildscript {
     repositories {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // For 5.0.0, hard code to reflect SDK version
-        OneSignalWrapper.setSdkVersion("050406");
+        OneSignalWrapper.setSdkVersion("050500");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Flutter (1.0.0)
-  - onesignal_flutter (5.3.4):
+  - onesignal_flutter (5.5.0):
     - Flutter
     - OneSignalXCFramework (= 5.5.0)
   - OneSignalXCFramework (5.5.0):
@@ -78,7 +78,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  onesignal_flutter: fa28e94a7baa3cd8b503fc4d760103405882f47f
+  onesignal_flutter: 786a2ae8d69120f3041f0f1de326bee63b319e3e
   OneSignalXCFramework: 943852e7d70d719f73e9669d48620aeec1b93022
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/examples/demo/lib/widgets/sections/live_activities_section.dart
+++ b/examples/demo/lib/widgets/sections/live_activities_section.dart
@@ -85,18 +85,6 @@ class _LiveActivitiesSectionState extends State<LiveActivitiesSection> {
           SizedBox(
             width: double.infinity,
             child: OutlinedButton(
-              onPressed: activityEmpty ? null : () => vm.exitLiveActivity(),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: AppColors.osPrimary,
-                side: const BorderSide(color: AppColors.osPrimary),
-              ),
-              child: const Text('STOP UPDATING LIVE ACTIVITY'),
-            ),
-          ),
-          AppSpacing.gapBox,
-          SizedBox(
-            width: double.infinity,
-            child: OutlinedButton(
               onPressed: activityEmpty || !vm.hasApiKey
                   ? null
                   : () => vm.endLiveActivity(),

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.3.4'
+  s.version          = '5.5.0'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
                 .product(name: "OneSignalInAppMessages", package: "OneSignal-XCFramework"),
                 .product(name: "OneSignalLocation", package: "OneSignal-XCFramework"),
                 .product(name: "OneSignalExtension", package: "OneSignal-XCFramework"),
+                .product(name: "OneSignalLiveActivities", package: "OneSignal-XCFramework"),
             ],
             cSettings: [
                 .headerSearchPath("include/onesignal_flutter")

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
                 .product(name: "OneSignalInAppMessages", package: "OneSignal-XCFramework"),
                 .product(name: "OneSignalLocation", package: "OneSignal-XCFramework"),
                 .product(name: "OneSignalExtension", package: "OneSignal-XCFramework"),
-                .product(name: "OneSignalLiveActivities", package: "OneSignal-XCFramework"),
             ],
             cSettings: [
                 .headerSearchPath("include/onesignal_flutter")

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050406";
+  OneSignalWrapper.sdkVersion = @"050500";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/lib/src/liveactivities.dart
+++ b/lib/src/liveactivities.dart
@@ -19,7 +19,8 @@ class OneSignalLiveActivities {
   /// Indicate this device has exited a live activity, identified within OneSignal by the [activityId].
   ///
   /// Only applies to iOS.
-  @Deprecated('This API is no longer supported and will be removed in a future release.')
+  @Deprecated(
+      'This API is no longer supported and will be removed in a future release.')
   Future<void> exitLiveActivity(String activityId) async {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       return await _channel.invokeMethod(

--- a/lib/src/liveactivities.dart
+++ b/lib/src/liveactivities.dart
@@ -19,8 +19,7 @@ class OneSignalLiveActivities {
   /// Indicate this device has exited a live activity, identified within OneSignal by the [activityId].
   ///
   /// Only applies to iOS.
-  @Deprecated(
-      'Currently unsupported, avoid using this method.')
+  @Deprecated('Currently unsupported, avoid using this method.')
   Future<void> exitLiveActivity(String activityId) async {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       return await _channel.invokeMethod(

--- a/lib/src/liveactivities.dart
+++ b/lib/src/liveactivities.dart
@@ -20,7 +20,7 @@ class OneSignalLiveActivities {
   ///
   /// Only applies to iOS.
   @Deprecated(
-      'This API is no longer supported and will be removed in a future release.')
+      'Currently unsupported, avoid using this method.')
   Future<void> exitLiveActivity(String activityId) async {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       return await _channel.invokeMethod(

--- a/lib/src/liveactivities.dart
+++ b/lib/src/liveactivities.dart
@@ -5,7 +5,7 @@ class OneSignalLiveActivities {
   // private channels used to bridge to ObjC/Java
   MethodChannel _channel = const MethodChannel('OneSignal#liveactivities');
 
-  /// Indicate this device has exited a live activity, identified within OneSignal by the [activityId]. The
+  /// Indicate this device has entered a live activity, identified within OneSignal by the [activityId]. The
   /// [token] is the ActivityKit's update token that will be used to update the live activity.
   ///
   /// Only applies to iOS.
@@ -19,6 +19,7 @@ class OneSignalLiveActivities {
   /// Indicate this device has exited a live activity, identified within OneSignal by the [activityId].
   ///
   /// Only applies to iOS.
+  @Deprecated('This API is no longer supported and will be removed in a future release.')
   Future<void> exitLiveActivity(String activityId) async {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       return await _channel.invokeMethod(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.4.6
+version: 5.5.0
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts

--- a/test/liveactivities_test.dart
+++ b/test/liveactivities_test.dart
@@ -39,6 +39,7 @@ void main() {
 
     group('exitLiveActivity', () {
       test('invokes OneSignal#exitLiveActivity with activityId', () async {
+        // ignore: deprecated_member_use_from_same_package
         await liveActivities.exitLiveActivity(activityId);
 
         expect(channelController.state.liveActivityExited, true);


### PR DESCRIPTION
Channels: Current

### 🚀 New Features

- feat: add Swift Package Manager support for iOS plugin (#1131)

**Swift Package Manager (SPM) Support:** Flutter's SPM integration is used automatically when enabled (the default in newer Flutter versions). No changes are needed for new projects.

**Migrating from CocoaPods to SPM:** Existing projects using CocoaPods can migrate by:
1. Remove `enable-swift-package-manager: false` from `pubspec.yaml` (if present)
2. Delete `Podfile`, `Podfile.lock`, and `Pods/` directory
3. Remove CocoaPods include lines from `ios/Flutter/Debug.xcconfig` and `ios/Flutter/Release.xcconfig`
4. Run `flutter run`, Flutter adds SPM integration automatically