### PR TITLE
chore: Release 5.5.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.5.0'
+version '5.5.1'
 
 buildscript {
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.7.6'
+    implementation 'com.onesignal:OneSignal:5.7.7'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // For 5.0.0, hard code to reflect SDK version
-        OneSignalWrapper.setSdkVersion("050500");
+        OneSignalWrapper.setSdkVersion("050501");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -23,7 +23,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.context = context;
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
-        // For 5.0.0, hard code to reflect SDK version
+        // Keep in sync with pubspec.yaml version
         OneSignalWrapper.setSdkVersion("050501");
 
         channel = new MethodChannel(messenger, "OneSignal");

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.5.0'
+  s.version          = '5.5.1'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050500";
+  OneSignalWrapper.sdkVersion = @"050501";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.5.0
+version: 5.5.1
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.6 to 5.7.7
  - fix: [SDK-4192] downgrade Kotlin from 2.2.0 to 1.9.25 ([#2601](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2601))


