### PR TITLE
chore: Release 5.5.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.5.1'
+version '5.5.2'
 
 buildscript {
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.7.7'
+    implementation 'com.onesignal:OneSignal:5.8.0'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050501");
+        OneSignalWrapper.setSdkVersion("050502");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.5.1'
+  s.version          = '5.5.2'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'onesignal_flutter/Sources/onesignal_flutter/**/*.{h,m}'
   s.public_header_files = 'onesignal_flutter/Sources/onesignal_flutter/include/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.5.0'
+  s.dependency 'OneSignalXCFramework', '5.5.1'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.0"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.1"),
     ],
     targets: [
         .target(

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050501";
+  OneSignalWrapper.sdkVersion = @"050502";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.5.1
+version: 5.5.2
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.7 to 5.8.0
  - feat: hash PII (email/SMS) in SharedPreferences at rest ([#2620](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2620))
  - feat: SDK-4176: gate background threading behind remote feature flag ([#2595](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2595))
  - feat: SDK-4210: Standardize BACKGROUND_THREADING feature flag key naming ([#2598](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2598))
  - feat: SDK-4363: Turbine remote SDK feature flags and foreground refresh ([#2612](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2612))
  - bug: catch exception if opening a notification fails ([#2508](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2508))
  - Fix: a rare NPE from PermissionViewModel ([#2504](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2504))
  - fix: add retry for notification opened confirmation ([#2606](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2606))
  - fix: end initialization early if device storage is locked ([#2520](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2520))
- Update iOS SDK from 5.5.0 to 5.5.1
  - fix: update unattributed outcomes to match attributed outcomes and Android SDK ([OneSignal-iOS-SDK#1655](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1655))
