### PR TITLE
chore: Release 5.5.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.5.6'
+version '5.5.7'
 
 buildscript {
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.onesignal:OneSignal:5.9.2'
+    implementation 'com.onesignal:OneSignal:5.9.3'
 }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050506");
+        OneSignalWrapper.setSdkVersion("050507");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'onesignal_flutter/Sources/onesignal_flutter/**/*.{h,m}'
   s.public_header_files = 'onesignal_flutter/Sources/onesignal_flutter/include/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'OneSignalXCFramework', '5.5.1'
+  s.dependency 'OneSignalXCFramework', '5.5.2'
   s.ios.deployment_target = '11.0'
   s.static_framework = true
 end

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'onesignal_flutter'
-  s.version          = '5.5.6'
+  s.version          = '5.5.7'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.1"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.2"),
     ],
     targets: [
         .target(

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050506";
+  OneSignalWrapper.sdkVersion = @"050507";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.5.6
+version: 5.5.7
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.2 to 5.9.3
  - fix: [SDK-4732] track activity lifecycle from process start to fix late-init focus ([#2655](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2655))
  - fix: [SDK-4735] route requestPermission fallbackToSettings to settings when permanently denied ([#2656](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2656))
- Update iOS SDK from 5.5.1 to 5.5.2
  - fix: Preserve user identity across iOS prewarm launches ([OneSignal-iOS-SDK#1669](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1669))
