### PR TITLE
fix: [SDK-4736] move Flutter bridge off main thread

### DIFF
--- a/android/src/main/java/com/onesignal/flutter/FlutterMessengerResponder.java
+++ b/android/src/main/java/com/onesignal/flutter/FlutterMessengerResponder.java
@@ -3,12 +3,25 @@ package com.onesignal.flutter;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
+import com.onesignal.debug.internal.logging.Logging;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 abstract class FlutterMessengerResponder {
+    private static final ExecutorService BACKGROUND_EXECUTOR = Executors.newSingleThreadExecutor(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "OneSignalFlutterBg");
+            thread.setDaemon(true);
+            return thread;
+        }
+    });
+
     Context context;
     protected MethodChannel channel;
     BinaryMessenger messenger;
@@ -102,6 +115,20 @@ abstract class FlutterMessengerResponder {
             Handler handler = new Handler(Looper.getMainLooper());
             handler.post(runnable);
         }
+    }
+
+    void runOnBackgroundThread(final MethodChannel.Result result, final Runnable runnable) {
+        BACKGROUND_EXECUTOR.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    runnable.run();
+                } catch (Exception e) {
+                    Logging.error("Encountered an error while handling a Flutter method call: " + e.toString(), e);
+                    replyError(result, "OneSignal", e.getMessage(), null);
+                }
+            }
+        });
     }
 
     void invokeMethodOnUiThread(final String methodName, final HashMap map) {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalInAppMessages.java
@@ -40,7 +40,16 @@ public class OneSignalInAppMessages extends FlutterMessengerResponder
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        runOnBackgroundThread(result, new Runnable() {
+            @Override
+            public void run() {
+                handleMethodCall(call, result);
+            }
+        });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#addTrigger")) this.addTriggers(call, result);
         else if (call.method.contentEquals("OneSignal#addTriggers")) this.addTriggers(call, result);
         else if (call.method.contentEquals("OneSignal#removeTrigger")) this.removeTrigger(call, result);

--- a/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalLocation.java
@@ -28,7 +28,16 @@ public class OneSignalLocation extends FlutterMessengerResponder implements Meth
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        runOnBackgroundThread(result, new Runnable() {
+            @Override
+            public void run() {
+                handleMethodCall(call, result);
+            }
+        });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#requestPermission")) this.requestPermission(result);
         else if (call.method.contentEquals("OneSignal#setShared")) this.setShared(call, result);
         else if (call.method.contentEquals("OneSignal#isShared"))

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -84,6 +84,8 @@ public class OneSignalNotifications extends FlutterMessengerResponder
 
     @Override
     public void onMethodCall(final MethodCall call, final Result result) {
+        // These paths only use cached foreground events and must not wait behind
+        // SDK calls that can block during initialization.
         if (call.method.contentEquals("OneSignal#displayNotification")) this.displayNotification(call, result);
         else if (call.method.contentEquals("OneSignal#preventDefault")) this.preventDefault(call, result);
         else if (call.method.contentEquals("OneSignal#proceedWithWillDisplay"))

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -33,7 +33,7 @@ public class OneSignalNotifications extends FlutterMessengerResponder
 
     // #1138: tracks if Dart requested clicks, so we can queue (not drop) them
     // while the channel is detached across engine/activity lifecycles.
-    private boolean clickListenerRequested = false;
+    private volatile boolean clickListenerRequested = false;
 
     public static OneSignalNotifications getSharedInstance() {
         if (sharedInstance == null) {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalNotifications.java
@@ -16,6 +16,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import kotlin.coroutines.Continuation;
 import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.Dispatchers;
@@ -26,8 +27,9 @@ public class OneSignalNotifications extends FlutterMessengerResponder
         implements MethodCallHandler, INotificationClickListener, INotificationLifecycleListener, IPermissionObserver {
     private static OneSignalNotifications sharedInstance;
 
-    private final HashMap<String, INotificationWillDisplayEvent> notificationOnWillDisplayEventCache = new HashMap<>();
-    private final HashMap<String, INotificationWillDisplayEvent> preventedDefaultCache = new HashMap<>();
+    private final Map<String, INotificationWillDisplayEvent> notificationOnWillDisplayEventCache =
+            new ConcurrentHashMap<>();
+    private final Map<String, INotificationWillDisplayEvent> preventedDefaultCache = new ConcurrentHashMap<>();
 
     // #1138: tracks if Dart requested clicks, so we can queue (not drop) them
     // while the channel is detached across engine/activity lifecycles.
@@ -81,7 +83,21 @@ public class OneSignalNotifications extends FlutterMessengerResponder
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        if (call.method.contentEquals("OneSignal#displayNotification")) this.displayNotification(call, result);
+        else if (call.method.contentEquals("OneSignal#preventDefault")) this.preventDefault(call, result);
+        else if (call.method.contentEquals("OneSignal#proceedWithWillDisplay"))
+            this.proceedWithWillDisplay(call, result);
+        else
+            runOnBackgroundThread(result, new Runnable() {
+                @Override
+                public void run() {
+                    handleMethodCall(call, result);
+                }
+            });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#permission"))
             replySuccess(result, OneSignal.getNotifications().getPermission());
         else if (call.method.contentEquals("OneSignal#canRequest"))
@@ -91,11 +107,7 @@ public class OneSignalNotifications extends FlutterMessengerResponder
         else if (call.method.contentEquals("OneSignal#removeGroupedNotifications"))
             this.removeGroupedNotifications(call, result);
         else if (call.method.contentEquals("OneSignal#clearAll")) this.clearAll(call, result);
-        else if (call.method.contentEquals("OneSignal#displayNotification")) this.displayNotification(call, result);
-        else if (call.method.contentEquals("OneSignal#preventDefault")) this.preventDefault(call, result);
         else if (call.method.contentEquals("OneSignal#lifecycleInit")) this.lifecycleInit(result);
-        else if (call.method.contentEquals("OneSignal#proceedWithWillDisplay"))
-            this.proceedWithWillDisplay(call, result);
         else if (call.method.contentEquals("OneSignal#addNativeClickListener")) this.registerClickListener();
         else replyNotImplemented(result);
     }

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -86,7 +86,16 @@ public class OneSignalPlugin extends FlutterMessengerResponder
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        runOnBackgroundThread(result, new Runnable() {
+            @Override
+            public void run() {
+                handleMethodCall(call, result);
+            }
+        });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#initialize")) this.initWithContext(call, result);
         else if (call.method.contentEquals("OneSignal#consentRequired")) this.setConsentRequired(call, result);
         else if (call.method.contentEquals("OneSignal#consentGiven")) this.setConsentGiven(call, result);

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPushSubscription.java
@@ -33,7 +33,16 @@ public class OneSignalPushSubscription extends FlutterMessengerResponder
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        runOnBackgroundThread(result, new Runnable() {
+            @Override
+            public void run() {
+                handleMethodCall(call, result);
+            }
+        });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#optIn")) this.optIn(call, result);
         else if (call.method.contentEquals("OneSignal#optOut")) this.optOut(call, result);
         else if (call.method.contentEquals("OneSignal#pushSubscriptionId"))

--- a/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalSession.java
@@ -27,7 +27,16 @@ public class OneSignalSession extends FlutterMessengerResponder implements Metho
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        runOnBackgroundThread(result, new Runnable() {
+            @Override
+            public void run() {
+                handleMethodCall(call, result);
+            }
+        });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#addOutcome")) this.addOutcome(call, result);
         else if (call.method.contentEquals("OneSignal#addUniqueOutcome")) this.addUniqueOutcome(call, result);
         else if (call.method.contentEquals("OneSignal#addOutcomeWithValue")) this.addOutcomeWithValue(call, result);

--- a/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalUser.java
@@ -34,7 +34,16 @@ public class OneSignalUser extends FlutterMessengerResponder implements MethodCa
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(final MethodCall call, final Result result) {
+        runOnBackgroundThread(result, new Runnable() {
+            @Override
+            public void run() {
+                handleMethodCall(call, result);
+            }
+        });
+    }
+
+    private void handleMethodCall(MethodCall call, Result result) {
         if (call.method.contentEquals("OneSignal#setLanguage")) this.setLanguage(call, result);
         else if (call.method.contentEquals("OneSignal#getOnesignalId")) this.getOnesignalId(call, result);
         else if (call.method.contentEquals("OneSignal#getExternalId")) this.getExternalId(call, result);

--- a/examples/demo/android/gradle.properties
+++ b/examples/demo/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/demo/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/demo/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/examples/demo/ios/Runner/AppDelegate.swift
+++ b/examples/demo/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/examples/demo/ios/Runner/Info.plist
+++ b/examples/demo/ios/Runner/Info.plist
@@ -26,12 +26,33 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSSupportsLiveActivities</key>
-	<true/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app uses your location to personalize notifications and content.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This app uses your location to personalize notifications and content, even in the background.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app uses your location to personalize notifications and content.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/examples/demo/lib/main.dart
+++ b/examples/demo/lib/main.dart
@@ -70,7 +70,8 @@ Future<void> main() async {
     debugPrint(
       'Notification foreground will display: ${event.notification.title}',
     );
-    event.notification.display();
+    // event.preventDefault(); // This will prevent the notification from being displayed
+    // event.notification.display(); // This will override the preventDefault and display the notification
   });
 
   // Set up API service


### PR DESCRIPTION
## One Line Summary
Move Android Flutter bridge calls that touch OneSignal SDK accessors off the main thread to avoid startup ANRs while preserving notification response timing.

## Motivation
Android MethodChannel handlers run on the platform thread, and OneSignal SDK accessors can block in `waitForInit()` during initialization. Moving SDK-facing bridge work to a shared background executor prevents that wait from blocking the UI thread.

## Scope
- Adds a shared serial background executor for Android bridge handlers that call into the native SDK.
- Keeps cache-only notification response paths immediate so foreground notification handling is not queued behind init-sensitive work.
- Makes notification event caches and click listener state safe across bridge/lifecycle threads.
- Includes committed demo compatibility updates needed by the branch.

## Testing
- `flutter analyze`
- `dart run rps format-check`
- `dart run rps test` (257 tests, 98.6% coverage)
- `flutter build apk --debug` from `examples/demo`
- Manual verifier run on `Android_16` and `iPhone 17` with fresh app installs and notification permissions accepted:
  - Android permission changed to true and push subscription updated to optedIn=true / SUBSCRIBED.
  - iOS permission changed to true and push subscription updated to optedIn=true.
  - No Android `waitForInit`, `runBlocking`, fatal exception, or ANR signal under the Flutter plugin path.

## Affected Code Checklist
- [x] Android native bridge
- [x] Flutter example app
- [ ] Dart public API
- [ ] iOS SDK bridge

## Checklist
- [x] Branch targets `main`.
- [x] Unrelated untracked verifier script is not included in the PR.
- [x] Manual permission prompt regression testing completed on emulator/simulator.

Made with [Cursor](https://cursor.com)