### PR TITLE
chore: Release 5.6.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.6.1'
+version '5.6.2'
 
 def safeEnvFlagGet(prop) {
     def value = System.getenv(prop)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ def safeEnvFlagGet(prop) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.3'
+def oneSignalVersion = '5.9.4'
 def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
 
 buildscript {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050601");
+        OneSignalWrapper.setSdkVersion("050602");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 
   s.name             = 'onesignal_flutter'
-  s.version          = '5.6.1'
+  s.version          = '5.6.2'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  onesignal_xcframework_version = '5.5.2'
+  onesignal_xcframework_version = '5.5.3'
   onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050601";
+  OneSignalWrapper.sdkVersion = @"050602";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.6.1
+version: 5.6.2
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.3 to 5.9.4
  - fix: demote spurious ANR log from warn to info ([#2660](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2660))
- Update iOS SDK from 5.5.2 to 5.5.3
  - fix: prevent stale FetchUser from clobbering the current user's identity ([OneSignal-iOS-SDK#1672](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1672))
