### PR TITLE
fix: update release PR native SDK version handling

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -85,7 +85,7 @@ jobs:
 
           # Get versions from target branch (not the release branch)
           CURRENT_VERSION=$(git show origin/${{ inputs.target_branch }}:pubspec.yaml | grep "^version:" | sed 's/version: //' | tr -d ' ')
-          ANDROID_VERSION=$(git show origin/${{ inputs.target_branch }}:android/build.gradle | sed -n "s/.*com\.onesignal:OneSignal:\([^']*\)'.*/\1/p")
+          ANDROID_VERSION=$(git show origin/${{ inputs.target_branch }}:android/build.gradle | sed -n "s/^def oneSignalVersion = ['\"]\([^'\"]*\)['\"].*/\1/p")
           IOS_VERSION=$(git show origin/${{ inputs.target_branch }}:ios/onesignal_flutter.podspec | sed -n "s/.*OneSignalXCFramework', '\([^']*\)'.*/\1/p")
 
           echo "flutter_from=$CURRENT_VERSION" >> $GITHUB_OUTPUT
@@ -109,7 +109,7 @@ jobs:
 
           # Update build.gradle with new version
           # macOS sed syntax
-          sed -i '' "s|implementation 'com\.onesignal:OneSignal:[^']*'|implementation 'com.onesignal:OneSignal:${VERSION}'|" android/build.gradle
+          sed -i '' -E "s|^def oneSignalVersion = ['\"][^'\"]*['\"]|def oneSignalVersion = '${VERSION}'|" android/build.gradle
           echo "✓ Updated android/build.gradle with Android SDK ${VERSION}"
 
           # Only commit if there are changes

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -86,7 +86,7 @@ jobs:
           # Get versions from target branch (not the release branch)
           CURRENT_VERSION=$(git show origin/${{ inputs.target_branch }}:pubspec.yaml | grep "^version:" | sed 's/version: //' | tr -d ' ')
           ANDROID_VERSION=$(git show origin/${{ inputs.target_branch }}:android/build.gradle | sed -n "s/^def oneSignalVersion = ['\"]\([^'\"]*\)['\"].*/\1/p")
-          IOS_VERSION=$(git show origin/${{ inputs.target_branch }}:ios/onesignal_flutter.podspec | sed -n "s/.*OneSignalXCFramework', '\([^']*\)'.*/\1/p")
+          IOS_VERSION=$(git show origin/${{ inputs.target_branch }}:ios/onesignal_flutter.podspec | sed -n "s/^[[:space:]]*onesignal_xcframework_version = ['\"]\([^'\"]*\)['\"].*/\1/p")
 
           echo "flutter_from=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "android_from=$ANDROID_VERSION" >> $GITHUB_OUTPUT
@@ -133,7 +133,7 @@ jobs:
 
           # Update onesignal_flutter.podspec with new version
           # macOS sed syntax
-          sed -i '' "s|s.dependency 'OneSignalXCFramework', '[^']*'|s.dependency 'OneSignalXCFramework', '${VERSION}'|" ios/onesignal_flutter.podspec
+          sed -i '' -E "s|^([[:space:]]*onesignal_xcframework_version = )['\"][^'\"]*['\"]|\\1'${VERSION}'|" ios/onesignal_flutter.podspec
           echo "✓ Updated ios/onesignal_flutter.podspec with iOS SDK ${VERSION}"
 
           # Update Package.swift with new version


### PR DESCRIPTION
## One Line Summary
Fix the Create Release PR workflow so native Android and iOS SDK inputs update the version variables currently used by the SDK manifests.

## Motivation
The Android Gradle file and iOS podspec now store native SDK versions in local variables, but the release PR workflow was still reading and replacing the previous inline dependency formats. This could leave release PRs with stale native SDK versions.

## Scope
Updates `.github/workflows/create-release-pr.yml` to read and update `oneSignalVersion` in `android/build.gradle` and `onesignal_xcframework_version` in `ios/onesignal_flutter.podspec`.

Keeps the existing `Package.swift` iOS SDK update behavior unchanged.

## Testing
- `ReadLints` on `.github/workflows/create-release-pr.yml`
- `git diff --check -- .github/workflows/create-release-pr.yml`
- Local `sed` simulations for the Android and iOS version-variable replacements

## Affected code checklist
- [x] CI / GitHub Actions
- [ ] Android runtime code
- [ ] iOS runtime code
- [ ] Dart API surface
- [ ] Documentation

## Checklist
- [x] Changes are scoped to the release PR workflow
- [x] Version replacement commands are aligned with the current manifest formats

Made with [Cursor](https://cursor.com)