### PR TITLE
chore: Release 5.6.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.6.2'
+version '5.6.3'
 
 def safeEnvFlagGet(prop) {
     def value = System.getenv(prop)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ def safeEnvFlagGet(prop) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.4'
+def oneSignalVersion = '5.9.5'
 def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
 
 buildscript {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050602");
+        OneSignalWrapper.setSdkVersion("050603");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 
   s.name             = 'onesignal_flutter'
-  s.version          = '5.6.2'
+  s.version          = '5.6.3'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050602";
+  OneSignalWrapper.sdkVersion = @"050603";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.6.2
+version: 5.6.3
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.4 to 5.9.5
  - fix(notifications): guard against null PendingResult from goAsync() [SDK-4803] ([#2667](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2667))
  - fix: prevent location permission crashes from FusedLocation API calls ([#2653](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2653))
  - fix: [SDK-4672] start location updates when permission is granted ([#2663](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2663))
  - fix: [SDK-4793] prevent main-thread ANR in blocking SDK APIs during/after init ([#2666](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2666))
  - fix: [SDK-4794] prewarm dispatchers at cold-start entry points ([#2664](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2664))


