### PR TITLE
chore: Release 5.6.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.6.3'
+version '5.6.4'
 
 def safeEnvFlagGet(prop) {
     def value = System.getenv(prop)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ def safeEnvFlagGet(prop) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.5'
+def oneSignalVersion = '5.9.6'
 def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
 
 buildscript {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050603");
+        OneSignalWrapper.setSdkVersion("050604");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  onesignal_xcframework_version = '5.5.3'
+  onesignal_xcframework_version = '5.5.4'
   onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 
   s.name             = 'onesignal_flutter'
-  s.version          = '5.6.3'
+  s.version          = '5.6.4'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.3"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.4"),
     ],
     targets: [
         .target(

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050603";
+  OneSignalWrapper.sdkVersion = @"050604";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.6.3
+version: 5.6.4
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.5 to 5.9.6
  - fix: [SDK-4513] display queued in-app messages on unpause when triggers still match ([#2682](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2682))
  - fix: [SDK-4734] move HMS notification finish() inside coroutine so entryState is set before trampoline stops ([#2678](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2678))
  - fix: [SDK-4792] keep devices subscribed when a push token fetch temporarily fails ([#2670](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2670))
  - fix: [SDK-4820] ship consumer dontwarn rule for OpenTelemetry to prevent R8 missing-class build failures ([#2677](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2677))
  - fix: [SDK-4822] make ANR watchdog app-state aware to stop false background ANRs ([#2676](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2676))
  - fix: [SDK-4841] prewarm dispatchers at process start via ActivityLifecycleInitializer ([#2680](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2680))
  - fix: [SDK-4845] always finish base notification trampoline via finally ([#2681](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2681))
- Update iOS SDK from 5.5.3 to 5.5.4
  - fix: [SDK-4814] Live Activities Confirmed Receipts exceeding Delivered count ([OneSignal-iOS-SDK#1681](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1681))
  - fix: restore local tags cleared by a concurrent FetchUser ([OneSignal-iOS-SDK#1678](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1678))
  - fix: [SDK-4757] recover startup when initialized before UIApplicationMain ([OneSignal-iOS-SDK#1677](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1677))
