### PR TITLE
chore: Release 5.6.5

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -98,11 +98,10 @@ jobs:
           VERSION="${{ inputs.android_version }}"
 
           # Validate version exists on GitHub
-          RELEASE=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/OneSignal/OneSignal-Android-SDK/releases/tags/${VERSION}")
-
-
-          if [ -z "$RELEASE" ]; then
+          if ! curl --fail --silent --show-error --retry 4 --retry-delay 30 \
+            -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/OneSignal/OneSignal-Android-SDK/releases/tags/${VERSION}" \
+            >/dev/null; then
             echo "✗ Android SDK version ${VERSION} not found"
             exit 1
           fi
@@ -123,10 +122,10 @@ jobs:
           VERSION="${{ inputs.ios_version }}"
 
           # Validate version exists on GitHub
-          RELEASE=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/OneSignal/OneSignal-iOS-SDK/releases/tags/${VERSION}")
-
-          if [ -z "$RELEASE" ]; then
+          if ! curl --fail --silent --show-error --retry 4 --retry-delay 30 \
+            -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/OneSignal/OneSignal-iOS-SDK/releases/tags/${VERSION}" \
+            >/dev/null; then
             echo "✗ iOS SDK version ${VERSION} not found"
             exit 1
           fi

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.6.4'
+version '5.6.5'
 
 def safeEnvFlagGet(prop) {
     def value = System.getenv(prop)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ def safeEnvFlagGet(prop) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.6'
+def oneSignalVersion = '5.9.7'
 def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
 
 buildscript {

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050604");
+        OneSignalWrapper.setSdkVersion("050605");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 
   s.name             = 'onesignal_flutter'
-  s.version          = '5.6.4'
+  s.version          = '5.6.5'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050604";
+  OneSignalWrapper.sdkVersion = @"050605";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.6.4
+version: 5.6.5
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.6 to 5.9.7
  - fix: narrow overly broad consumer ProGuard/R8 keep rules ([#2679](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2679))
  - fix: preserve WorkDatabase constructor under R8 ([#2685](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2685))


