### PR TITLE
chore: [SDK-4970] resolve duplicate XCFramework build error when location is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ env:
 
 With the location module disabled, calls to `OneSignal.Location` are ignored on Android and `OneSignal.Location.isShared()` returns `false`.
 
+##### CocoaPods: app extension targets
+
+CocoaPods only builds `OneSignalXCFramework` once when **every** target in your
+Podfile resolves the same set of subspecs. If the sets differ, it creates one
+pod variant per set, and each variant tries to write the same extracted
+framework, which fails the build with:
+
+```
+error: Multiple commands produce '.../XCFrameworkIntermediates/OneSignalXCFramework/OneSignalCore/OneSignalCore.framework'
+```
+
+With location disabled the plugin resolves `OneSignalXCFramework/OneSignal` and
+`OneSignalXCFramework/OneSignalInAppMessages`, so every Notification Service
+Extension or Widget Extension target must declare those same two subspecs:
+
+```ruby
+target 'OneSignalNotificationServiceExtension' do
+  use_frameworks!
+  pod 'OneSignalXCFramework/OneSignal', '>= 5.0.0', '< 6.0'
+  pod 'OneSignalXCFramework/OneSignalInAppMessages', '>= 5.0.0', '< 6.0'
+end
+```
+
+Without the environment variable set, the plugin resolves the umbrella pod, so
+extension targets should declare `pod 'OneSignalXCFramework'` instead. Either
+way the rule is the same: the app target and every extension target must request
+an identical subspec set.
+
 ##### Applying the change (clearing cached packages)
 
 The environment variable is only read when dependencies are **resolved**, and

--- a/examples/build-ios.md
+++ b/examples/build-ios.md
@@ -28,6 +28,14 @@ target 'OneSignalWidgetExtension' do
 end
 ```
 
+Every target must request the same subspec set, otherwise CocoaPods builds a
+separate `OneSignalXCFramework` variant per set and the extracted frameworks
+collide with `Multiple commands produce`. If you build with
+`ONESIGNAL_DISABLE_LOCATION=true`, the plugin resolves
+`OneSignalXCFramework/OneSignal` plus `OneSignalXCFramework/OneSignalInAppMessages`,
+so both extension targets must declare those two subspecs instead of the
+umbrella pod.
+
 ---
 
 ## 2. Runner: entitlements + Info.plist

--- a/examples/demo-no-location-pods/README.md
+++ b/examples/demo-no-location-pods/README.md
@@ -49,15 +49,16 @@ The helper script installs the CocoaPods dependencies before launching the app.
 The app does not include `NSLocationWhenInUseUsageDescription` or
 `NSLocationAlwaysAndWhenInUseUsageDescription`.
 
-The iOS project includes a `OneSignalNotificationServiceExtension` target like
-the main demo. The extension depends on `OneSignalXCFramework/OneSignal`, while
-the Flutter plugin also resolves `OneSignalInAppMessages`. This currently
-reproduces the duplicate XCFramework output error reported in
-[GitHub issue #1173](https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/1173).
+The iOS project includes `OneSignalNotificationServiceExtension` and
+`OneSignalWidgetExtension` targets like the main demo. On iOS 16.2 or newer, use
+the app's **Start Live Activity** button to launch the sample widget.
 
-It also includes a `OneSignalWidgetExtension` target using the modular
-`OneSignalLiveActivities` subspec. On iOS 16.2 or newer, use the app's
-**Start Live Activity** button to launch the sample widget.
+Both extension targets declare `OneSignalXCFramework/OneSignal` and
+`OneSignalXCFramework/OneSignalInAppMessages`, matching what the Flutter plugin
+resolves when location is disabled. CocoaPods only builds one
+`OneSignalXCFramework` when every target requests the same subspec set;
+mismatched sets produce duplicate framework outputs and the build error reported
+in [GitHub issue #1173](https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/1173).
 
 ## Android
 

--- a/examples/demo-no-location-pods/ios/Podfile
+++ b/examples/demo-no-location-pods/ios/Podfile
@@ -35,11 +35,13 @@ end
 target 'OneSignalNotificationServiceExtension' do
   use_frameworks!
   pod 'OneSignalXCFramework/OneSignal', '>= 5.0.0', '< 6.0'
+  pod 'OneSignalXCFramework/OneSignalInAppMessages', '>= 5.0.0', '< 6.0'
 end
 
 target 'OneSignalWidgetExtension' do
   use_frameworks!
-  pod 'OneSignalXCFramework/OneSignalLiveActivities', '>= 5.0.0', '< 6.0'
+  pod 'OneSignalXCFramework/OneSignal', '>= 5.0.0', '< 6.0'
+  pod 'OneSignalXCFramework/OneSignalInAppMessages', '>= 5.0.0', '< 6.0'
 end
 
 post_install do |installer|

--- a/examples/demo-no-location-pods/ios/Podfile.lock
+++ b/examples/demo-no-location-pods/ios/Podfile.lock
@@ -47,7 +47,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - onesignal_flutter (from `.symlinks/plugins/onesignal_flutter/ios`)
   - OneSignalXCFramework/OneSignal (< 6.0, >= 5.0.0)
-  - OneSignalXCFramework/OneSignalLiveActivities (< 6.0, >= 5.0.0)
+  - OneSignalXCFramework/OneSignalInAppMessages (< 6.0, >= 5.0.0)
 
 SPEC REPOS:
   trunk:
@@ -64,6 +64,6 @@ SPEC CHECKSUMS:
   onesignal_flutter: 7c54486bcf26464bee36e75e7f866c2824f9fe5e
   OneSignalXCFramework: 48e5b7c5b51d4e67bab3405229f963efde1a3894
 
-PODFILE CHECKSUM: 54529446f4556256849941004b3ba5b9e04e1b4f
+PODFILE CHECKSUM: ca6bd8db026875e601ab6a118e9b108c0910f5de
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
> Stacked on #1176. Review that one first. This PR's diff is 5 files once GitHub shows it against `fadi/sdk-4970`.

## One Line Summary

Fixes the `Multiple commands produce` build failure by making iOS app extension targets declare the same OneSignal subspec set as the plugin, and documents the rule.

## Motivation

Reported in [SDK-4970](https://linear.app/onesignal/issue/SDK-4970/bug-multiple-commands-produce-build-error-in-xcode-when-disabling) and [#1173](https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/1173).

CocoaPods only builds `OneSignalXCFramework` once when every target in the Podfile resolves an identical subspec set. When the sets differ it creates one pod target variant per set, and each variant emits a `[CP] Copy XCFrameworks` phase writing to `XCFrameworkIntermediates/<rootPod>/<subspec>/<Name>.framework`. That path is keyed on the spec rather than the pod target, so overlapping subspecs collide and Xcode fails the build.

With location enabled this never surfaces, because the plugin declares the umbrella pod and our docs tell customers to declare the same umbrella in extension targets. Disabling location switches the plugin to `OneSignalXCFramework/OneSignal` plus `OneSignalXCFramework/OneSignalInAppMessages` while extensions still follow the old guidance, the sets diverge, and the build breaks:

```
error: Multiple commands produce '.../XCFrameworkIntermediates/OneSignalXCFramework/OneSignalCore/OneSignalCore.framework'
```

SPM is unaffected since it resolves products per target with no subspec deduplication.

## Scope

Documentation and one example Podfile. No SDK source or podspec changes.

- `README.md` gains a CocoaPods section under the location-disable docs explaining the rule, including the error text so people searching for it land there
- `examples/build-ios.md` notes the requirement where extension targets are set up
- `examples/demo-no-location-pods/ios/Podfile` declares both subspecs in the NSE and widget targets
- The demo README explains why, instead of describing the demo as a reproduction

## Testing

- `ONESIGNAL_DISABLE_LOCATION=true flutter build ios --debug --simulator` succeeds on `demo-no-location-pods`. On the base branch it fails with eight `Multiple commands produce` errors
- `pod install` produces a single `OneSignalXCFramework` pod target instead of three hash-suffixed variants
- `flutter analyze` clean at the repo root

## Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirmed Deliveries
  - [ ] Influenced Opens
  - [ ] Badges
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] Push Permission Prompt
- [ ] Email
- [ ] SMS
- [ ] Triggers
- [ ] Live Activities
- [ ] User Model
- [x] Other: iOS CocoaPods integration docs

## Checklist

- [x] I have filled out all REQUIRED sections above
- [x] I have added or updated tests, or this change does not require them
- [x] I have updated documentation where applicable
- [x] This change is backwards compatible

## Related

Follow-up filed as [SDK-4972](https://linear.app/onesignal/issue/SDK-4972/add-a-no-location-subspec-alias-to-onesignalxcframework) to add a `OneSignalNoLocation` subspec alias to `OneSignalXCFramework`, so customers declare one name instead of maintaining a subspec list that has to track our podspec. The same issue is latent in the Capacitor, Cordova, and React Native wrappers, which share this podspec conditional.

## Stack

1. #1176 example scaffolding
2. This PR