### PR TITLE
chore: Release 5.6.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ def safeEnvFlagGet(prop) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.8'
+def oneSignalVersion = '5.9.9'
 def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.6.7'
+version '5.6.8'
 
 def safeEnvFlagGet(prop) {
     def value = System.getenv(prop)

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050607");
+        OneSignalWrapper.setSdkVersion("050608");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 
   s.name             = 'onesignal_flutter'
-  s.version          = '5.6.7'
+  s.version          = '5.6.8'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  onesignal_xcframework_version = '5.5.5'
+  onesignal_xcframework_version = '5.5.6'
   onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.5"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.6"),
     ],
     targets: [
         .target(

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050607";
+  OneSignalWrapper.sdkVersion = @"050608";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.6.7
+version: 5.6.8
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.8 to 5.9.9
  - chore(logger): adopt shared KMP logger module via OneSignal-KMP-SDK submodule ([#2687](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2687))
  - chore(logger): gate otel-vs-logger switch on SDK_CUSTOM_LOGGING flag ([#2688](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2688))
  - chore(logger): wire Android FileLogStore for shared KMP legacy purge ([#2691](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2691))
  - chore(logger): log release-diagnostic info at SDK startup ([#2692](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2692))
  - chore: emit Kotlin version on remote log resource attrs ([#2713](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2713))
  - chore: adopt shared KMP feature-flags client and catalog ([#2716](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2716))
  - fix: restrict notification component exports ([#2659](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2659))
  - fix: forward PermissionsActivity theme fix ([#2701](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2701))
  - fix: skip ShortcutBadger on API 26+ to prevent SIGSEGV on Xiaomi devices ([#2570](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2570))
  - fix: destroy IAM WebView on dismiss to stop Activity leaks ([#2706](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2706))
- Update iOS SDK from 5.5.5 to 5.5.6
  - fix: resolve TOCTOU race on the current user ([OneSignal-iOS-SDK#1695](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1695))
  - fix: lock OSSubscriptionModel state to stop encode crashes ([OneSignal-iOS-SDK#1694](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1694))
  - refactor: rebuild OperationRepo unmatched delta queue on flush ([OneSignal-iOS-SDK#1693](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1693))
