### PR TITLE
chore: [SDK-5128] add explicit Android notification grouping to demos

### DIFF
--- a/examples/demo-fm/lib/services/onesignal_api_service.dart
+++ b/examples/demo-fm/lib/services/onesignal_api_service.dart
@@ -38,6 +38,7 @@ class OneSignalApiService {
     final body = <String, dynamic>{
       'app_id': _appId,
       'include_subscription_ids': [subscriptionId],
+      'android_group': 'demo-group',
       'headings': {'en': type.title},
       'contents': {'en': type.body},
     };
@@ -65,6 +66,7 @@ class OneSignalApiService {
     final payload = <String, dynamic>{
       'app_id': _appId,
       'include_subscription_ids': [subscriptionId],
+      'android_group': 'demo-group',
       'headings': {'en': title},
       'contents': {'en': body},
     };

--- a/examples/demo-no-location-pods/lib/main.dart
+++ b/examples/demo-no-location-pods/lib/main.dart
@@ -222,6 +222,7 @@ class _NoLocationDemoScreenState extends State<NoLocationDemoScreen> {
         body: jsonEncode({
           'app_id': _oneSignalAppId,
           'include_subscription_ids': [pushSubscriptionId],
+          'android_group': 'demo-group',
           'headings': {'en': 'OneSignal No-Location Demo'},
           'contents': {
             'en':

--- a/examples/demo-no-location/lib/main.dart
+++ b/examples/demo-no-location/lib/main.dart
@@ -222,6 +222,7 @@ class _NoLocationDemoScreenState extends State<NoLocationDemoScreen> {
         body: jsonEncode({
           'app_id': _oneSignalAppId,
           'include_subscription_ids': [pushSubscriptionId],
+          'android_group': 'demo-group',
           'headings': {'en': 'OneSignal No-Location Demo'},
           'contents': {
             'en':

--- a/examples/demo-pods/lib/services/onesignal_api_service.dart
+++ b/examples/demo-pods/lib/services/onesignal_api_service.dart
@@ -38,6 +38,7 @@ class OneSignalApiService {
     final body = <String, dynamic>{
       'app_id': _appId,
       'include_subscription_ids': [subscriptionId],
+      'android_group': 'demo-group',
       'headings': {'en': type.title},
       'contents': {'en': type.body},
     };
@@ -65,6 +66,7 @@ class OneSignalApiService {
     final payload = <String, dynamic>{
       'app_id': _appId,
       'include_subscription_ids': [subscriptionId],
+      'android_group': 'demo-group',
       'headings': {'en': title},
       'contents': {'en': body},
     };

--- a/examples/demo/lib/services/onesignal_api_service.dart
+++ b/examples/demo/lib/services/onesignal_api_service.dart
@@ -38,6 +38,7 @@ class OneSignalApiService {
     final body = <String, dynamic>{
       'app_id': _appId,
       'include_subscription_ids': [subscriptionId],
+      'android_group': 'demo-group',
       'headings': {'en': type.title},
       'contents': {'en': type.body},
     };
@@ -65,6 +66,7 @@ class OneSignalApiService {
     final payload = <String, dynamic>{
       'app_id': _appId,
       'include_subscription_ids': [subscriptionId],
+      'android_group': 'demo-group',
       'headings': {'en': title},
       'contents': {'en': body},
     };

--- a/examples/flutter-local-notif/lib/main.dart
+++ b/examples/flutter-local-notif/lib/main.dart
@@ -322,6 +322,7 @@ class _NotificationHomePageState extends State<NotificationHomePage> {
         body: jsonEncode({
           'app_id': _oneSignalAppId,
           'include_subscription_ids': [subscriptionId],
+          'android_group': 'demo-group',
           'headings': {'en': 'OneSignal notification'},
           'contents': {
             'en': 'Tap this to compare local and OneSignal response listeners.',


### PR DESCRIPTION
# Description

## One Line Summary

Send Flutter demo notifications with a deterministic `android_group` so OneSignal manages grouping.

## Details

Linear: SDK-5128.

Android 16 auto-groups ungrouped notifications and tapping the system summary can skip OneSignal click data. Demo send paths now set `android_group` to `demo-group`, matching the React Native demo.

# Testing

- Static checks passed.
- Device tap-on-summary click data still needs a physical Android 16 check.

# Checklist

- [x] Demo send paths use a shared Android group key
- [x] No public API changes
