### PR TITLE
chore: Release 5.6.9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ def safeEnvFlagGet(prop) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.9'
+def oneSignalVersion = '5.10.0'
 def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.onesignal.flutter'
-version '5.6.8'
+version '5.6.9'
 
 def safeEnvFlagGet(prop) {
     def value = System.getenv(prop)

--- a/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
+++ b/android/src/main/java/com/onesignal/flutter/OneSignalPlugin.java
@@ -24,7 +24,7 @@ public class OneSignalPlugin extends FlutterMessengerResponder
         this.messenger = messenger;
         OneSignalWrapper.setSdkType("flutter");
         // Keep in sync with pubspec.yaml version
-        OneSignalWrapper.setSdkVersion("050608");
+        OneSignalWrapper.setSdkVersion("050609");
 
         channel = new MethodChannel(messenger, "OneSignal");
         channel.setMethodCallHandler(this);

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  onesignal_xcframework_version = '5.6.0'
+  onesignal_xcframework_version = '5.6.1'
   onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  onesignal_xcframework_version = '5.5.6'
+  onesignal_xcframework_version = '5.6.0'
   onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 
   s.name             = 'onesignal_flutter'
-  s.version          = '5.6.8'
+  s.version          = '5.6.9'
   s.summary          = 'The OneSignal Flutter SDK'
   s.description      = 'Allows you to easily add OneSignal to your flutter projects, to make sending and handling push notifications easy'
   s.homepage         = 'https://www.onesignal.com'

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.6.0"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.6.1"),
     ],
     targets: [
         .target(

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.5.6"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework", exact: "5.6.0"),
     ],
     targets: [
         .target(

--- a/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
+++ b/ios/onesignal_flutter/Sources/onesignal_flutter/OneSignalPlugin.m
@@ -56,7 +56,7 @@
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
 
   OneSignalWrapper.sdkType = @"flutter";
-  OneSignalWrapper.sdkVersion = @"050608";
+  OneSignalWrapper.sdkVersion = @"050609";
   [OneSignal initialize:nil withLaunchOptions:nil];
 
   OneSignalPlugin.sharedInstance.channel =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onesignal_flutter
 description: OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your flutter app with OneSignal
-version: 5.6.8
+version: 5.6.9
 homepage: https://github.com/OneSignal/OneSignal-Flutter-SDK
 
 # Uses rps package for scripts


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes

- fix: [SDK-5161] support shared template notification actions (#1179)

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.9 to 5.10.0
  - feat: detect restored notifications and stop them re-alerting ([#2723](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2723))
  - feat: send host FID-readiness signals on API request headers ([#2729](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2729))
  - refactor: remove the otel observability path and OpenTelemetry dependency ([#2724](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2724))
- Update iOS SDK from 5.5.6 to 5.6.1
  - fix: restore the deprecated 2-arg NSE selector ([OneSignal-iOS-SDK#1737](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1737))
  - feat: report host app build toolchain on iOS logs ([OneSignal-iOS-SDK#1728](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1728))
  - feat: call KMP features API and wire flags into OSFeatureManager ([OneSignal-iOS-SDK#1723](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1723))
  - feat: drive iOS logging from remote params ([OneSignal-iOS-SDK#1722](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1722))
  - feat: enable KMP logger on Mac Catalyst ([OneSignal-iOS-SDK#1714](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1714))
  - feat: add iOS KMP crash capture and upload ([OneSignal-iOS-SDK#1713](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1713))
  - feat: wire KMP remote logging lifecycle ([OneSignal-iOS-SDK#1703](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1703))
  - feat: add Swift adapters for KMP logger ([OneSignal-iOS-SDK#1702](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1702))
  - fix: report unbuildable log requests as a permanent failure ([OneSignal-iOS-SDK#1727](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1727))
  - fix: bound the crash-record cache on iOS ([OneSignal-iOS-SDK#1725](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1725))
  - refactor: delegate KMP bumps to shared workflow ([OneSignal-iOS-SDK#1720](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1720))
