### PR TITLE
fix: update iOS minimum version to 12

### DIFF
--- a/ios/onesignal_flutter.podspec
+++ b/ios/onesignal_flutter.podspec
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
   else
     s.dependency 'OneSignalXCFramework', onesignal_xcframework_version
   end
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.static_framework = true
 end

--- a/ios/onesignal_flutter/Package.swift
+++ b/ios/onesignal_flutter/Package.swift
@@ -24,7 +24,7 @@ if !oneSignalDisableLocation {
 let package = Package(
     name: "onesignal_flutter",
     platforms: [
-        .iOS("11.0")
+        .iOS("12.0")
     ],
     products: [
         .library(name: "onesignal-flutter", targets: ["onesignal_flutter"])


### PR DESCRIPTION
# Description
## One Line Summary
Align the Flutter plugin's CocoaPods and Swift Package Manager minimum deployment targets with OneSignal iOS 5.6.x.

## Motivation
OneSignalXCFramework 5.6.1 requires iOS 12, while the Flutter podspec and Swift package manifest declared iOS 11.

## Scope
Raises the minimum iOS deployment target from iOS 11 to iOS 12 in:
- `ios/onesignal_flutter.podspec`
- `ios/onesignal_flutter/Package.swift`

# Testing
No tests were added because this is package metadata only.

Validated with:
- `pod ipc spec ios/onesignal_flutter.podspec`
- `swift package dump-package`
- `flutter analyze`
- `dart run rps test`

# Affected code checklist
- [x] Notifications / Push Processing
- [ ] Public API changes

# Checklist
- [x] Required sections completed
- [x] PR does one thing
- [x] Applicable automated checks pass
- [x] Device testing is not applicable to package metadata
- [x] Self-reviewed
